### PR TITLE
Initial steps to config Edn::Char

### DIFF
--- a/src/edn/mod.rs
+++ b/src/edn/mod.rs
@@ -17,7 +17,7 @@ pub enum Edn {
     UInt(usize),
     Double(f64),
     Rational(String),
-    // Char(char),
+    Char(char),
     Bool(bool),
     Nil,
 }
@@ -112,6 +112,7 @@ impl core::fmt::Display for Edn {
             Edn::Rational(r) => r.to_string(),
             Edn::Bool(b) => format!("{}", b),
             Edn::Nil => String::from("nil"),
+            Edn::Char(c) => format!("\\{}", c),
         };
         write!(f, "{}", text)
     }
@@ -146,6 +147,7 @@ impl Edn {
             Edn::Rational(r) => rational_to_double(&r),
             Edn::Bool(_) => None,
             Edn::Nil => None,
+            Edn::Char(_) => None,
         }
     }
 
@@ -177,6 +179,7 @@ impl Edn {
             Edn::Rational(r) => Some(rational_to_double(&r).unwrap_or(0f64).round() as isize),
             Edn::Bool(_) => None,
             Edn::Nil => None,
+            Edn::Char(_) => None,
         }
     }
 

--- a/src/edn/utils/index.rs
+++ b/src/edn/utils/index.rs
@@ -124,6 +124,7 @@ impl<'a> fmt::Display for Type<'a> {
             Edn::Symbol(_) => formatter.write_str("symbol"),
             Edn::Double(_) => formatter.write_str("double"),
             Edn::Rational(_) => formatter.write_str("rational"),
+            Edn::Char(_) => formatter.write_str("char"),
         }
     }
 }

--- a/src/edn/utils/mod.rs
+++ b/src/edn/utils/mod.rs
@@ -107,3 +107,9 @@ impl Attribute for bool {
         format!("{}",self.to_owned())
     }
 }
+
+impl Attribute for char {
+    fn process(&self) -> String {
+        format!("\\{}",self.to_owned())
+    }
+}

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -244,6 +244,11 @@ macro_rules! edn_internal {
         Edn::Symbol(symbol)
     }};
 
+    // The EDN char format is `\c` for type char `'c'`, but Rust doesn't allow this pattern in macro_rules
+    // (\$c:tt) => {
+    //     Edn::Char($c)
+    // };
+
     ($e:expr) => {
         match $crate::edn::utils::Attribute::process(&$e) {
             el if el.parse::<i32>().is_ok() => Edn::Int(el.parse::<isize>().unwrap()),

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -11,6 +11,11 @@ mod tests {
     };
 
     #[test]
+    fn parse_char() {
+        assert_eq!(edn!(\c), Edn::Char('c'))
+    }
+
+    #[test]
     fn parse_primitive_types() {
         assert_eq!(edn!(1), Edn::Int(1));
         assert_eq!(edn!(12.5), Edn::Double(12.5));


### PR DESCRIPTION
Problem:
`The EDN char format is \c for type char 'c', but Rust doesn't allow this pattern in macro_rules`

Relevant discussion to the topic https://internals.rust-lang.org/t/idea-escaping-macro-separators/7877/11