### PR TITLE
edn: use proper Rust Set type/collection internally for Edn::Set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ edition = "2018"
 
 [dependencies]
 regex = "1"
+ordered-float = "1.1"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ fn main() {
         List::new(
             vec![
                 Edn::Symbol("sym".to_string()),
-                Edn::Double(1.2),
+                Edn::Double(1.2.into()),
                 Edn::Int(3),
                 Edn::Bool(false),
                 Edn::Key("f".to_string()),
@@ -44,7 +44,7 @@ To navigate through `Edn` data you can just use `get` and `get_mut`:
 let edn = edn!([ 1 1.2 3 {false :f nil 3/4}]);
 
 assert_eq!(edn[1], edn!(1.2));
-assert_eq!(edn[1], Edn::Double(1.2f64));
+assert_eq!(edn[1], Edn::Double(1.2f64.into()));
 assert_eq!(edn[3]["false"], edn!(:f));
 assert_eq!(edn[3]["false"], Edn::Key("f".to_string()));
 ```
@@ -54,25 +54,30 @@ assert_eq!(edn[3]["false"], Edn::Key("f".to_string()));
  #![recursion_limit="512"]
  #[macro_use] extern crate edn_rs;
  
- use std::collections::{HashMap, HashSet};
+ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
  use crate::edn_rs::serialize::Serialize;
  
  fn main() {
      ser_struct!{
-         #[derive(Debug)]
+         #[derive(Debug, Clone)]
          struct Edn {
-             map: HashMap<String, Vec<String>>,
-             set: HashSet<i64>,
+             btreemap: BTreeMap<String, Vec<String>>,
+             btreeset: BTreeSet<i64>,
+             hashmap: HashMap<String, Vec<String>>,
+             hashset: HashSet<i64>,
              tuples: (i32, bool, char),
          }
      };
      let edn = Edn {
-         map: map!{"this is a key".to_string() => vec!["with".to_string(), "many".to_string(), "keys".to_string()]},
-         set: set!{3i64, 4i64, 5i64},
+         btreemap: map!{"this is a key".to_string() => vec!["with".to_string(), "many".to_string(), "keys".to_string()]},
+         btreeset: set!{3i64, 4i64, 5i64},
+         hashmap: hmap!{"this is a key".to_string() => vec!["with".to_string(), "many".to_string(), "keys".to_string()]},
+         hashset: hset!{3i64},
          tuples: (3i32, true, 'd')
      };
+
      println!("{}",edn.serialize());
-     // { :map {:this-is-a-key ["with", "many", "keys"]}, :set #{3, 4, 5}, :tuples (3, true, \d), }
+     // { :btreemap {:this-is-a-key [\"with\", \"many\", \"keys\"]}, :btreeset #{3, 4, 5}, :hashmap {:this-is-a-key [\"with\", \"many\", \"keys\"]}, :hashset #{3}, :tuples (3, true, \\d), }
  }
 ```
 
@@ -99,7 +104,7 @@ assert_eq!(edn[3]["false"], Edn::Key("f".to_string()));
     - [x] Symbol `sym-bol-s`
     - [x] Vector `"[1 :2 \"d\"]"`
     - [x] List `"(1 :2 \"d\")"`
-    - [x] Set `"#{1 2 3}"` For now the usage of Set is defined as a `Vec<Edn>`, this is due to the fact that the lib should not be necessarily responsible for assuring the Set's unicity. A solution could be changing the implementation to `HashSet`.
+    - [x] Set `"#{1 2 3}"`
     - [x] Map `"{:a 1 :b 2 }"`
 - [ ] Simple data structures in one another:
     - [x] Vec in Vec `"[1 2 [:3 \"4\"]]"`

--- a/src/edn/utils/index.rs
+++ b/src/edn/utils/index.rs
@@ -19,7 +19,6 @@ impl Index for usize {
         match *v {
             Edn::Vector(ref vec) => vec.0.get(*self),
             Edn::List(ref vec) => vec.0.get(*self),
-            Edn::Set(ref vec) => vec.0.get(*self),
             _ => None,
         }
     }
@@ -27,7 +26,6 @@ impl Index for usize {
         match *v {
             Edn::Vector(ref mut vec) => vec.0.get_mut(*self),
             Edn::List(ref mut vec) => vec.0.get_mut(*self),
-            Edn::Set(ref mut vec) => vec.0.get_mut(*self),
             _ => None,
         }
     }
@@ -62,7 +60,7 @@ impl Index for str {
     }
     fn index_or_insert<'v>(&self, v: &'v mut Edn) -> &'v mut Edn {
         if let Edn::Nil = *v {
-            *v = Edn::Map(Map::new(std::collections::HashMap::new()));
+            *v = Edn::Map(Map::new(std::collections::BTreeMap::new()));
         }
         match *v {
             Edn::Map(ref mut map) => map.0.entry(self.to_owned()).or_insert(Edn::Nil),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,15 +16,15 @@ pub mod edn;
 /// ```rust
 /// #[macro_use] extern crate edn_rs;
 /// 
-/// use std::collections::{HashMap, HashSet};
+/// use std::collections::{BTreeMap, BTreeSet};
 /// use crate::edn_rs::serialize::Serialize;
 /// 
 /// fn main() {
 ///     ser_struct!{
 ///         #[derive(Debug)]
 ///         struct Edn {
-///             map: HashMap<String, Vec<String>>,
-///             set: HashSet<i64>,
+///             map: BTreeMap<String, Vec<String>>,
+///             set: BTreeSet<i64>,
 ///             tuples: (i32, bool, char),
 ///         }
 ///     };

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -205,6 +205,54 @@ macro_rules! ser_hashmap_str {
     };
 }
 
+macro_rules! ser_btreemap {
+    ( $( $name:ty ),+ ) => {
+        $(
+            impl Serialize for std::collections::BTreeMap<String, $name>
+            {
+                fn serialize(self) -> String {
+                    let aux_vec = self.iter()
+                        .map(|(k, v)|
+                            format!(":{} {}",
+                            k.to_string().replace(" ", "-").replace("_", "-"),
+                            v.to_owned().serialize())
+                        )
+                        .collect::<Vec<String>>();
+                    let mut s = String::new();
+                    s.push_str("{");
+                    s.push_str(&aux_vec.join(", "));
+                    s.push_str("}");
+                    s
+                }
+            }
+        )+
+    };
+}
+
+macro_rules! ser_btreemap_str {
+    ( $( $name:ty ),+ ) => {
+        $(
+            impl Serialize for std::collections::BTreeMap<&str, $name>
+            {
+                fn serialize(self) -> String {
+                    let aux_vec = self.iter()
+                        .map(|(k, v)|
+                            format!(":{} {}",
+                            k.to_string().replace(" ", "-").replace("_", "-"),
+                            v.to_owned().serialize())
+                        )
+                        .collect::<Vec<String>>();
+                    let mut s = String::new();
+                    s.push_str("{");
+                    s.push_str(&aux_vec.join(", "));
+                    s.push_str("}");
+                    s
+                }
+            }
+        )+
+    };
+}
+
 // Primitive Types
 ser_primitives![i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, f32, f64, bool];
 ser_option_primitives![Option<i8>, Option<i16>, Option<i32>, Option<i64>, Option<isize>, Option<u8>, Option<u16>, 
@@ -302,6 +350,10 @@ ser_hashmap![i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, f32, f64, bool,
 ser_hashmap_str![i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, f32, f64, bool, String, &str];
 ser_hashmap![Vec<i8>, Vec<i16>, Vec<i32>, Vec<i64>, Vec<isize>, Vec<u8>, Vec<u16>, Vec<u32>, Vec<u64>, Vec<usize>, Vec<f32>, Vec<f64>, Vec<bool>, Vec<String>, Vec<&str>];
 ser_hashmap_str![Vec<i8>, Vec<i16>, Vec<i32>, Vec<i64>, Vec<isize>, Vec<u8>, Vec<u16>, Vec<u32>, Vec<u64>, Vec<usize>, Vec<f32>, Vec<f64>, Vec<bool>, Vec<String>, Vec<&str>];
+ser_btreemap![i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, f32, f64, bool, String, &str];
+ser_btreemap_str![i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, f32, f64, bool, String, &str];
+ser_btreemap![Vec<i8>, Vec<i16>, Vec<i32>, Vec<i64>, Vec<isize>, Vec<u8>, Vec<u16>, Vec<u32>, Vec<u64>, Vec<usize>, Vec<f32>, Vec<f64>, Vec<bool>, Vec<String>, Vec<&str>];
+ser_btreemap_str![Vec<i8>, Vec<i16>, Vec<i32>, Vec<i64>, Vec<isize>, Vec<u8>, Vec<u16>, Vec<u32>, Vec<u64>, Vec<usize>, Vec<f32>, Vec<f64>, Vec<bool>, Vec<String>, Vec<&str>];
 
 use std::collections::HashMap;
 ser_vec![HashMap<String, i8>, HashMap<String, i16>, HashMap<String, i32>, HashMap<String, i64>, HashMap<String, isize>, HashMap<String, u8>, HashMap<String, u16>, HashMap<String, u32>, HashMap<String, u64>, HashMap<String, usize>, HashMap<String, f32>, HashMap<String, f64>, HashMap<String, bool>, HashMap<String, String>, HashMap<String, &str>];

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -4,7 +4,7 @@
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, BTreeSet};
 
     use crate::edn_rs::{
         edn::{Edn, Set, Vector, List, Map},
@@ -13,7 +13,7 @@ mod tests {
     #[test]
     fn parse_primitive_types() {
         assert_eq!(edn!(1), Edn::Int(1));
-        assert_eq!(edn!(12.5), Edn::Double(12.5));
+        assert_eq!(edn!(12.5), Edn::Double(12.5.into()));
         assert_eq!(edn!(:key), Edn::Key("key".to_string()));
         assert_eq!(edn!("this is a string"), Edn::Str("this is a string".to_string()));
         assert_eq!(edn!(3/4), Edn::Rational("3/4".to_string()));
@@ -28,8 +28,8 @@ mod tests {
     fn parse_empty_structures() {
         assert_eq!(edn!([]), Edn::Vector(Vector::new(Vec::new())));
         assert_eq!(edn!(()), Edn::List(List::new(Vec::new())));
-        assert_eq!(edn!(#{}), Edn::Set(Set::new(Vec::new())));
-        assert_eq!(edn!({}), Edn::Map(Map::new(HashMap::new())));
+        assert_eq!(edn!(#{}), Edn::Set(Set::new(BTreeSet::new())));
+        assert_eq!(edn!({}), Edn::Map(Map::new(BTreeMap::new())));
     }
 
     #[test]
@@ -38,7 +38,7 @@ mod tests {
             Vector::new(
                 vec![
                     Edn::Symbol("sym".to_string()),
-                    Edn::Double(1.2),
+                    Edn::Double(1.2.into()),
                     Edn::Int(3),
                     Edn::Bool(false),
                     Edn::Key("f".to_string()),
@@ -57,7 +57,7 @@ mod tests {
             List::new(
                 vec![
                     Edn::Int(1),
-                    Edn::Double(1.2),
+                    Edn::Double(1.2.into()),
                     Edn::Int(3),
                     Edn::Bool(false),
                     Edn::Key("f".to_string()),
@@ -74,15 +74,15 @@ mod tests {
     fn parse_simple_set() {
         let expected = Edn::Set(
             Set::new(
-                vec![
+                set!{
                     Edn::Int(1),
-                    Edn::Double(1.2),
+                    Edn::Double(1.2.into()),
                     Edn::Int(3),
                     Edn::Bool(false),
                     Edn::Key("f".to_string()),
                     Edn::Nil,
                     Edn::Rational("3/4".to_string())
-                ]
+                }
             )
         );
 
@@ -109,7 +109,7 @@ mod tests {
             Vector::new(
                 vec![
                     Edn::Int(1),
-                    Edn::Double(1.2),
+                    Edn::Double(1.2.into()),
                     Edn::Int(3),
                     Edn::Vector(
                         Vector::new( vec![
@@ -131,7 +131,7 @@ mod tests {
             Vector::new(
                 vec![
                     Edn::Int(1),
-                    Edn::Double(1.2),
+                    Edn::Double(1.2.into()),
                     Edn::Int(3),
                     Edn::List(
                         List::new( vec![
@@ -153,7 +153,7 @@ mod tests {
             Vector::new(
                 vec![
                     Edn::Int(1),
-                    Edn::Double(1.2),
+                    Edn::Double(1.2.into()),
                     Edn::Int(3),
                     Edn::Map(
                         Map::new( map![
@@ -171,9 +171,9 @@ mod tests {
     fn parse_complex_set() {
         let expected = Edn::Set(
             Set::new(
-                vec![
+                set!{
                     Edn::Int(1),
-                    Edn::Double(1.2),
+                    Edn::Double(1.2.into()),
                     Edn::Int(3),
                     Edn::List(
                         List::new( vec![
@@ -188,7 +188,7 @@ mod tests {
                             Edn::Key("b".to_string()),
                             Edn::Rational("12/5".to_string())
                     ]))
-                ]
+                }
             )
         );
 
@@ -201,7 +201,7 @@ mod tests {
             List::new(
                 vec![
                     Edn::Int(1),
-                    Edn::Double(1.2),
+                    Edn::Double(1.2.into()),
                     Edn::Int(3),
                     Edn::Map(
                         Map::new( map![
@@ -227,7 +227,7 @@ mod tests {
         let edn = edn!([ 1 1.2 3 {false :f nil 3/4}]);
 
         assert_eq!(edn[1], edn!(1.2));
-        assert_eq!(edn[1], Edn::Double(1.2f64));
+        assert_eq!(edn[1], Edn::Double(1.2f64.into()));
         assert_eq!(edn[3]["false"], edn!(:f));
         assert_eq!(edn[3]["false"], Edn::Key("f".to_string()));
     }

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -3,7 +3,7 @@
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{HashMap, HashSet};
+    use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
     use crate::edn_rs::serialize::Serialize;
 
@@ -12,19 +12,22 @@ mod tests {
         ser_struct!{
             #[derive(Debug, Clone)]
             struct Edn {
-                map: HashMap<String, Vec<String>>,
-                set: HashSet<i64>,
+                btreemap: BTreeMap<String, Vec<String>>,
+                btreeset: BTreeSet<i64>,
+                hashmap: HashMap<String, Vec<String>>,
+                hashset: HashSet<i64>,
                 tuples: (i32, bool, char),
             }
         };
         let edn = Edn {
-            map: map!{"this is a key".to_string() => vec!["with".to_string(), "many".to_string(), "keys".to_string()]},
-            set: set!{3i64, 4i64, 5i64},
+            btreemap: map!{"this is a key".to_string() => vec!["with".to_string(), "many".to_string(), "keys".to_string()]},
+            btreeset: set!{3i64, 4i64, 5i64},
+            hashmap: hmap!{"this is a key".to_string() => vec!["with".to_string(), "many".to_string(), "keys".to_string()]},
+            hashset: hset!{3i64},
             tuples: (3i32, true, 'd')
         };
 
-        assert!(edn.clone().serialize().contains(":map {:this-is-a-key [\"with\", \"many\", \"keys\"]}")
-            && edn.clone().serialize().contains(":tuples (3, true, \\d),"));
+        assert_eq!(edn.serialize(), "{ :btreemap {:this-is-a-key [\"with\", \"many\", \"keys\"]}, :btreeset #{3, 4, 5}, :hashmap {:this-is-a-key [\"with\", \"many\", \"keys\"]}, :hashset #{3}, :tuples (3, true, \\d), }");
     }
 }
 


### PR DESCRIPTION
To actually use a `Set` Rust type internally for `Edn::Set` I had to do several changes, they are:

- I tried using `HashSet`, however since both `HashMap` and `HashSet` don't implement `Hash`, they can't be used as keys on `HashMap`s and/or values on `HashSet`s. Since this ain't' viable, I went with the `BTreeMap`/`BTreeSet` solution, which is the same as the [mentat/edn](https://github.com/mozilla/mentat/tree/master/edn) crate;
- Also since `HashSet<Edn::Double>` exists now, `Edn::Double` suddenly had to implement `Hash`. To make this happen I've used the `ordered_float` crate, just like the [mentat/edn](https://github.com/mozilla/mentat/tree/master/edn) did;
- Also I had to do some `serialization` and `macro` internal changes, because of the new types that I am using.

## Considerations on API Design

There is one thing I would like a second opinion. Before to use the variant `Edn::Double`, you could just pass a `f64` to it, like `Edn::Double(1.2)`.
Now since we will be using the `OrderedFloat`, I've created a public alias `Double` which just stands for `OrderedFloat<f64>`.

The problem with this is that the user has to either do `Edn::Double(Double(1.2))` or it can do `Edn::Double(1.2.into())` (more pleasant in my opinion). Do you think this is a problem/issue? If you are okay with the user having to do this conversion or use the new alias type then I think we can proceed normally.

By the way this is probably a **breaking change**, since `Edn::Double(1.2)` won't work anymore, and will have to be substituted by `Edn::Double(1.2.into())`. But still, is a very simple fix, and it doesn't affect macros at all, just the creation of `Edn` manually via enum 🙂 

Also, any suggestion is always welcome 😊 , the project is yours after all hahaha

Fixes https://github.com/naomijub/edn-rs/issues/3