### PR TITLE
Migrate `parse_edn` to `from_str`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,11 @@ fn main() {
 }
 ```
 
-**Parse an EDN String** with `parse_edn`:
+**Parse an EDN String** with `from_str`:
 ```rust
 use edn_rs::{
     set, map,
     Edn, Map, Vector, Set,
-    parse_edn
 };
 use std::str::FromStr;
 
@@ -69,7 +68,7 @@ fn main() -> Result<(), String> {
 
     // OR 
 
-    let edn_resp = parse_edn(edn_str)?;
+    let edn_resp = edn_rs::from_str(edn_str)?;
     assert_eq!(edn_resp[":b"][0], Edn::Bool(true));
     Ok(())
 }
@@ -163,7 +162,7 @@ fn main() {
 - [x] Define `struct` to map EDN info `EdnNode`
 - [x] Define EDN types, `EdnType`
  - [x] Edn Type into primitive: `Edn::Bool(true).into() -> true`. This was done by `to_float`, `to_bool`, `to_int`, `to_vec`.
-- [x] Parse EDN data [`parse_edn`](https://docs.rs/edn-rs/0.10.2/edn_rs/deserialize/fn.parse_edn.html):
+- [x] Parse EDN data [`from_str`](https://docs.rs/edn-rs/0.10.2/edn_rs/deserialize/fn.from_str.html):
     - [x] nil `""`
     - [x] String `"\"string\""`
     - [x] Numbers `"324352"`, `"3442.234"`, `"3/4"`

--- a/examples/parse_str.rs
+++ b/examples/parse_str.rs
@@ -1,4 +1,4 @@
-use edn_rs::{map, parse_edn, set, Edn, EdnError, Map, Set, Vector};
+use edn_rs::{map, set, Edn, EdnError, Map, Set, Vector};
 use std::str::FromStr;
 
 fn main() -> Result<(), EdnError> {
@@ -21,7 +21,7 @@ fn main() -> Result<(), EdnError> {
 
     // OR
 
-    let edn_resp = parse_edn(edn_str)?;
+    let edn_resp = edn_rs::from_str(edn_str)?;
     assert_eq!(edn_resp[":b"][0], Edn::Bool(true));
     Ok(())
 }

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -7,8 +7,8 @@ pub trait Deserialize: Sized {
     fn deserialize<S>(self) -> Result<Self, Error>;
 }
 
-/// `parse_edn` parses a EDN String into [`Edn`](../edn_rs/edn/enum.Edn.html)
-pub fn parse_edn(edn: &str) -> Result<Edn, Error> {
+/// `from_str` parses a EDN String into [`Edn`](../edn_rs/edn/enum.Edn.html)
+pub fn from_str(edn: &str) -> Result<Edn, Error> {
     let tokens = tokenize(edn);
 
     Ok(parse(&tokens[..])?.0)
@@ -178,7 +178,7 @@ mod test {
         let edn = "[1 \"2\" 3.3 :b true \\c]";
 
         assert_eq!(
-            parse_edn(edn),
+            from_str(edn),
             Ok(Edn::Vector(Vector::new(vec![
                 Edn::UInt(1),
                 Edn::Str("2".to_string()),
@@ -195,7 +195,7 @@ mod test {
         let edn = "(1 \"2\" 3.3 :b [true \\c])";
 
         assert_eq!(
-            parse_edn(edn),
+            from_str(edn),
             Ok(Edn::List(List::new(vec![
                 Edn::UInt(1),
                 Edn::Str("2".to_string()),
@@ -211,7 +211,7 @@ mod test {
         let edn = "(1 \"2\" 3.3 :b #{true \\c})";
 
         assert_eq!(
-            parse_edn(edn),
+            from_str(edn),
             Ok(Edn::List(List::new(vec![
                 Edn::UInt(1),
                 Edn::Str("2".to_string()),
@@ -227,7 +227,7 @@ mod test {
         let edn = "{:a \"2\" :b true :c nil}";
 
         assert_eq!(
-            parse_edn(edn),
+            from_str(edn),
             Ok(Edn::Map(Map::new(
                 map! {":a".to_string() => Edn::Str("2".to_string()),
                 ":b".to_string() => Edn::Bool(true), ":c".to_string() => Edn::Nil}
@@ -240,7 +240,7 @@ mod test {
         let edn = "{:a \"2\" :b [true false] :c #{:A {:a :b} nil}}";
 
         assert_eq!(
-            parse_edn(edn),
+            from_str(edn),
             Ok(Edn::Map(Map::new(map! {
             ":a".to_string() =>Edn::Str("2".to_string()),
             ":b".to_string() => Edn::Vector(Vector::new(vec![Edn::Bool(true), Edn::Bool(false)])),
@@ -257,7 +257,7 @@ mod test {
         let edn = "[\"hello brave new world\"]";
 
         assert_eq!(
-            parse_edn(edn).unwrap(),
+            from_str(edn).unwrap(),
             Edn::Vector(Vector::new(vec![Edn::Str(
                 "hello brave new world".to_string()
             )]))

--- a/src/edn/mod.rs
+++ b/src/edn/mod.rs
@@ -422,7 +422,7 @@ impl std::str::FromStr for Edn {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        crate::deserialize::parse_edn(s)
+        crate::deserialize::from_str(s)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub fn json_to_edn(json: String) -> String {
     edn.replace("null", "nil")
 }
 
-pub use deserialize::parse_edn;
+pub use deserialize::from_str;
 pub use edn::Error as EdnError;
 pub use edn::{Double, Edn, List, Map, Set, Vector};
 pub use serialize::Serialize;


### PR DESCRIPTION
We are doing this for better usability. Benchmarks with `serde`.

Co-authored-by: Julia Boeira <julia.boeira@nubank.com.br>