### PR TITLE
Migrate serialize to to_string

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ fn main() {
  ```rust
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use edn_rs::{
-    Serialize,
     ser_struct, map, set, hmap, hset
 };
 
@@ -124,7 +123,7 @@ fn main() {
         tuples: (3i32, true, 'd')
     };
 
-    println!("{}",edn.serialize());
+    println!("{}", edn_rs::to_string(edn));
     // { :btreemap {:this-is-a-key [\"with\", \"many\", \"keys\"]}, :btreeset #{3, 4, 5}, :hashmap {:this-is-a-key [\"with\", \"many\", \"keys\"]}, :hashset #{3}, :tuples (3, true, \\d), }
 }
 ```
@@ -235,10 +234,9 @@ edn-rs = 0.11.1"
 
 **Serialize**
 ```rust
-use edn_derive::Serialize as SerializeEdn;
-use edn_rs::Serialize;
+use edn_derive::Serialize;
 
-#[derive(SerializeEdn)]
+#[derive(Serialize)]
 pub struct Person {
     name: String,
     age: usize,
@@ -249,7 +247,10 @@ fn main() {
         name: "joana".to_string(),
         age: 290000,
     };
-    assert_eq!(person.serialize(), "{ :name \"joana\", :age 290000, }");
+    assert_eq!(
+        edn_rs::to_string(person),
+        "{ :name \"joana\", :age 290000, }"
+    );
 }
 ```
 

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -29,6 +29,6 @@ fn main() {
         foo_vec: vec![Foo { value: 2 }, Foo { value: 3 }],
     };
 
-    println!("{}", edn.serialize());
+    println!("{}", edn_rs::to_string(edn));
     // { :btreemap {:this-is-a-key [\"with\", \"many\", \"keys\"]}, :btreeset #{3, 4, 5}, :hashmap {:this-is-a-key [\"with\", \"many\", \"keys\"]}, :hashset #{3}, :tuples (3, true, \\d), :foo-vec [{ :value 2, }, { :value 3, }], }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub mod edn;
 ///         set: set!{3i64, 4i64, 5i64},
 ///         tuples: (3i32, true, 'd')
 ///     };
-///     println!("{}",edn.serialize());
+///     println!("{}", edn_rs::to_string(edn));
 ///     // { :map {:this-is-a-key ["with", "many", "keys"]}, :set #{3, 4, 5}, :tuples (3, true, \d), }
 /// }
 ///```
@@ -75,3 +75,37 @@ pub use deserialize::from_str;
 pub use edn::Error as EdnError;
 pub use edn::{Double, Edn, List, Map, Set, Vector};
 pub use serialize::Serialize;
+
+/// Function for converting Rust types into EDN Strings.
+/// For it to work, the type must implement the Serialize trait.
+/// For now you can do it via `ser_struct!` macro, in the future
+/// it will be via `#[derive(Serialize)]` from `edn-derive` crate.
+///
+/// Example:
+/// ```rust
+/// #[macro_use] extern crate edn_rs;
+///
+/// use std::collections::{BTreeMap, BTreeSet};
+/// use crate::edn_rs::Serialize;
+///
+/// fn main() {
+///     ser_struct!{
+///         #[derive(Debug)]
+///         struct Edn {
+///             map: BTreeMap<String, Vec<String>>,
+///             set: BTreeSet<i64>,
+///             tuples: (i32, bool, char),
+///         }
+///     };
+///     let edn = Edn {
+///         map: map!{"this is a key".to_string() => vec!["with".to_string(), "many".to_string(), "keys".to_string()]},
+///         set: set!{3i64, 4i64, 5i64},
+///         tuples: (3i32, true, 'd')
+///     };
+///     println!("{}", edn_rs::to_string(edn));
+///     // { :map {:this-is-a-key ["with", "many", "keys"]}, :set #{3, 4, 5}, :tuples (3, true, \d), }
+/// }
+///```
+pub fn to_string<T: Serialize>(t: T) -> String {
+    t.serialize()
+}


### PR DESCRIPTION
I've put `to_string` function on `lib.rs` but idk where is the best place for it.

Also we need to migrate at some point the `from_str` function out of the `deserialize` module.