### PR TITLE
Deserialize primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,10 @@ struct Person {
 }
 
 impl Deserialize for Person {
-    fn deserialize(edn: Edn) -> Result<Self, EdnError> {
+    fn deserialize(edn: &Edn) -> Result<Self, EdnError> {
         Ok(Self {
-            name: edn[":name"].to_string(),
-            age: edn[":age"].to_uint().ok_or_else(|| {
-                EdnError::Deserialize("couldn't convert `:age` into `uint`".to_string())
-            })?,
+            name: Deserialize::deserialize(&edn[":name"])?,
+            age: Deserialize::deserialize(&edn[":age"])?,
         })
     }
 }
@@ -164,13 +162,13 @@ fn main() -> Result<(), EdnError> {
     println!("{:?}", person);
     // Person { name: "rose", age: 66 }
 
-    let bad_edn_str = "{:name \"rose\" :age \"not an uint\"}";
+    let bad_edn_str = "{:name \"rose\" :age \"some text\"}";
     let person: Result<Person, EdnError> = edn_rs::from_str(bad_edn_str);
 
     assert_eq!(
         person,
         Err(EdnError::Deserialize(
-            "couldn't convert `:age` into `uint`".to_string()
+            "couldn't convert `some text` to `uint`".to_string()
         ))
     );
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ fn main() -> Result<(), EdnError> {
     assert_eq!(
         person,
         Err(EdnError::Deserialize(
-            "couldn't convert `some text` to `uint`".to_string()
+            "couldn't convert `some text` into `uint`".to_string()
         ))
     );
 

--- a/examples/complex_struct_deserialization.rs
+++ b/examples/complex_struct_deserialization.rs
@@ -66,7 +66,7 @@ fn main() -> Result<(), EdnError> {
     assert_eq!(
         complex,
         Err(EdnError::Deserialize(
-            "couldn't convert `some text` to `uint`".to_string()
+            "couldn't convert `some text` into `uint`".to_string()
         ))
     );
 

--- a/examples/complex_struct_deserialization.rs
+++ b/examples/complex_struct_deserialization.rs
@@ -1,0 +1,74 @@
+use edn_rs::{Deserialize, Edn, EdnError};
+
+#[derive(Debug, PartialEq)]
+struct Another {
+    name: String,
+    age: usize,
+    cool: bool,
+}
+
+impl Deserialize for Another {
+    fn deserialize(edn: &Edn) -> Result<Self, EdnError> {
+        Ok(Self {
+            name: Deserialize::deserialize(&edn[":name"])?,
+            age: Deserialize::deserialize(&edn[":age"])?,
+            cool: Deserialize::deserialize(&edn[":cool"])?,
+        })
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct Complex {
+    list: Vec<Another>,
+}
+
+impl Deserialize for Complex {
+    fn deserialize(edn: &Edn) -> Result<Self, EdnError> {
+        Ok(Self {
+            list: Deserialize::deserialize(&edn[":list"])?,
+        })
+    }
+}
+
+fn main() -> Result<(), EdnError> {
+    let edn_str = "{ :list [{:name \"rose\" :age 66 :cool true}, {:name \"josh\" :age 33 :cool false}, {:name \"eva\" :age 296 :cool true}] }";
+    let complex: Complex = edn_rs::from_str(edn_str)?;
+
+    assert_eq!(
+        complex,
+        Complex {
+            list: vec![
+                Another {
+                    name: "rose".to_string(),
+                    age: 66,
+                    cool: true,
+                },
+                Another {
+                    name: "josh".to_string(),
+                    age: 33,
+                    cool: false,
+                },
+                Another {
+                    name: "eva".to_string(),
+                    age: 296,
+                    cool: true,
+                },
+            ],
+        }
+    );
+
+    println!("{:?}", complex);
+    // Complex { list: [Another { name: "rose", age: 66, cool: true }, Another { name: "josh", age: 33, cool: false }, Another { name: "eva", age: 296, cool: true }] }
+
+    let bad_edn_str = "{ :list [{:name \"rose\" :age \"some text\" :cool true}, {:name \"josh\" :age 33 :cool false}, {:name \"eva\" :age 296 :cool true}] }";
+    let complex: Result<Complex, EdnError> = edn_rs::from_str(bad_edn_str);
+
+    assert_eq!(
+        complex,
+        Err(EdnError::Deserialize(
+            "couldn't convert `some text` to `uint`".to_string()
+        ))
+    );
+
+    Ok(())
+}

--- a/examples/struct_from_str.rs
+++ b/examples/struct_from_str.rs
@@ -7,12 +7,10 @@ struct Person {
 }
 
 impl Deserialize for Person {
-    fn deserialize(edn: Edn) -> Result<Self, EdnError> {
+    fn deserialize(edn: &Edn) -> Result<Self, EdnError> {
         Ok(Self {
-            name: edn[":name"].to_string(),
-            age: edn[":age"].to_uint().ok_or_else(|| {
-                EdnError::Deserialize("couldn't convert `:age` into `uint`".to_string())
-            })?,
+            name: Deserialize::deserialize(&edn[":name"])?,
+            age: Deserialize::deserialize(&edn[":age"])?,
         })
     }
 }
@@ -32,13 +30,13 @@ fn main() -> Result<(), EdnError> {
     println!("{:?}", person);
     // Person { name: "rose", age: 66 }
 
-    let bad_edn_str = "{:name \"rose\" :age \"not an uint\"}";
+    let bad_edn_str = "{:name \"rose\" :age \"some text\"}";
     let person: Result<Person, EdnError> = edn_rs::from_str(bad_edn_str);
 
     assert_eq!(
         person,
         Err(EdnError::Deserialize(
-            "couldn't convert `:age` into `uint`".to_string()
+            "couldn't convert `some text` to `uint`".to_string()
         ))
     );
 

--- a/examples/struct_from_str.rs
+++ b/examples/struct_from_str.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), EdnError> {
     assert_eq!(
         person,
         Err(EdnError::Deserialize(
-            "couldn't convert `some text` to `uint`".to_string()
+            "couldn't convert `some text` into `uint`".to_string()
         ))
     );
 

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -42,7 +42,7 @@ use std::str::FromStr;
 /// assert_eq!(
 ///     person,
 ///     Err(EdnError::Deserialize(
-///         "couldn't convert `some text` to `uint`".to_string()
+///         "couldn't convert `some text` into `uint`".to_string()
 ///     ))
 /// );
 /// ```
@@ -51,7 +51,7 @@ pub trait Deserialize: Sized {
 }
 
 fn build_deserialize_error(edn: Edn, type_: &str) -> Error {
-    Error::Deserialize(format!("couldn't convert `{}` to `{}`", edn, type_))
+    Error::Deserialize(format!("couldn't convert `{}` into `{}`", edn, type_))
 }
 
 macro_rules! impl_deserialize_float {

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -149,7 +149,10 @@ where
                 .unwrap()
                 .map(|e| Deserialize::deserialize(e))
                 .collect::<Result<Vec<T>, Error>>()?),
-            _ => Err(build_deserialize_error(edn.clone(), "Vec<T>")),
+            _ => Err(build_deserialize_error(
+                edn.clone(),
+                std::any::type_name::<Vec<T>>(),
+            )),
         }
     }
 }

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -128,38 +128,29 @@ impl Deserialize for char {
     }
 }
 
-impl Deserialize for Vec<String> {
+impl<T> Deserialize for Vec<T>
+where
+    T: Deserialize,
+{
     fn deserialize(edn: &Edn) -> Result<Self, Error> {
-        edn.to_vec()
-            .ok_or_else(|| build_deserialize_error(edn.clone(), "Vec<String>"))
-    }
-}
-
-impl Deserialize for Vec<isize> {
-    fn deserialize(edn: &Edn) -> Result<Self, Error> {
-        edn.to_int_vec()
-            .ok_or_else(|| build_deserialize_error(edn.clone(), "Vec<isize>"))
-    }
-}
-
-impl Deserialize for Vec<usize> {
-    fn deserialize(edn: &Edn) -> Result<Self, Error> {
-        edn.to_uint_vec()
-            .ok_or_else(|| build_deserialize_error(edn.clone(), "Vec<usize>"))
-    }
-}
-
-impl Deserialize for Vec<f64> {
-    fn deserialize(edn: &Edn) -> Result<Self, Error> {
-        edn.to_float_vec()
-            .ok_or_else(|| build_deserialize_error(edn.clone(), "Vec<f64>"))
-    }
-}
-
-impl Deserialize for Vec<bool> {
-    fn deserialize(edn: &Edn) -> Result<Self, Error> {
-        edn.to_bool_vec()
-            .ok_or_else(|| build_deserialize_error(edn.clone(), "Vec<bool>"))
+        match edn {
+            Edn::Vector(_) => Ok(edn
+                .iter()
+                .unwrap()
+                .map(|e| Deserialize::deserialize(e))
+                .collect::<Result<Vec<T>, Error>>()?),
+            Edn::List(_) => Ok(edn
+                .iter()
+                .unwrap()
+                .map(|e| Deserialize::deserialize(e))
+                .collect::<Result<Vec<T>, Error>>()?),
+            Edn::Set(_) => Ok(edn
+                .iter()
+                .unwrap()
+                .map(|e| Deserialize::deserialize(e))
+                .collect::<Result<Vec<T>, Error>>()?),
+            _ => Err(build_deserialize_error(edn.clone(), "Vec<T>")),
+        }
     }
 }
 


### PR DESCRIPTION
This will not only make the user have less trouble implementing `Deserialize`, but also will help us out on `edn-derive` for generic implementations over any type :tada: 