### PR TITLE
Add default Deserialization for Option<T>

### DIFF
--- a/examples/option_deserialization.rs
+++ b/examples/option_deserialization.rs
@@ -1,0 +1,63 @@
+use edn_rs::{Deserialize, Edn, EdnError};
+
+#[derive(Debug, PartialEq)]
+struct Another {
+    name: String,
+    age: usize,
+    cool: bool,
+}
+
+impl Deserialize for Another {
+    fn deserialize(edn: &Edn) -> Result<Self, EdnError> {
+        Ok(Self {
+            name: Deserialize::deserialize(&edn[":name"])?,
+            age: Deserialize::deserialize(&edn[":age"])?,
+            cool: Deserialize::deserialize(&edn[":cool"])?,
+        })
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct Complex {
+    id: usize,
+    maybe: Option<Another>,
+}
+
+impl Deserialize for Complex {
+    fn deserialize(edn: &Edn) -> Result<Self, EdnError> {
+        Ok(Self {
+            id: Deserialize::deserialize(&edn[":id"])?,
+            maybe: Deserialize::deserialize(&edn[":maybe"])?,
+        })
+    }
+}
+
+fn main() -> Result<(), EdnError> {
+    let edn_str = "{ :id 22 :maybe {:name \"rose\" :age 66 :cool true} }";
+    let complex: Complex = edn_rs::from_str(edn_str)?;
+
+    assert_eq!(
+        complex,
+        Complex {
+            id: 22,
+            maybe: Some(Another {
+                name: "rose".to_string(),
+                age: 66,
+                cool: true,
+            }),
+        }
+    );
+
+    println!("{:?}", complex);
+    // Complex { id: 22, maybe: Another { name: "rose", age: 66, cool: true } }
+
+    let edn_str = "{ :id 1 }";
+    let complex: Complex = edn_rs::from_str(edn_str)?;
+
+    assert_eq!(complex, Complex { id: 1, maybe: None });
+
+    println!("{:?}", complex);
+    // Complex { id: 1, maybe: None }
+
+    Ok(())
+}

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -157,6 +157,18 @@ where
     }
 }
 
+impl<T> Deserialize for Option<T>
+where
+    T: Deserialize,
+{
+    fn deserialize(edn: &Edn) -> Result<Self, Error> {
+        match edn {
+            Edn::Nil => Ok(None),
+            _ => Ok(Some(Deserialize::deserialize(&edn)?)),
+        }
+    }
+}
+
 /// `from_str` parses a EDN String into something that implements `TryFrom<Edn, Error = EdnError>`
 pub fn from_str<T: Deserialize>(s: &str) -> Result<T, Error> {
     let edn = Edn::from_str(s)?;


### PR DESCRIPTION
This deserialization will help on types that use `Option`, for example if someone makes a struct with a field `Option<CruxId>`, this will make it work :slightly_smiling_face: 