### PR TITLE
Benches serialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ futures = {version = "0.3.5", optional = true }
 [dev-dependencies]
 tokio = {version = "0.2.22", features = ["macros"] }
 criterion = "0.3"
+edn-derive = "*"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [dev-dependencies.cargo-husky]
 version = "1"
@@ -31,6 +34,10 @@ features = ["user-hooks"]
 
 [[bench]]
 name = "parse"
+harness = false
+
+[[bench]]
+name = "serialize"
 harness = false
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -249,6 +249,14 @@ async fn main() {
 }
 ```
 
+The objective of `foo` is to show that `Edn` can be wrapped with a `Future`. If you want to return an `Edn` from an `async` function just use:
+
+```rust
+async fn foo() -> Edn {
+    edn!([1 1.5 "hello" :key])
+}
+```
+
 ## Edn-rs Current Features
 - [x] Define `struct` to map EDN info `EdnNode`
 - [x] Define EDN types, `EdnType`

--- a/benches/serialize.rs
+++ b/benches/serialize.rs
@@ -1,0 +1,77 @@
+use criterion::{criterion_group, criterion_main};
+
+criterion_group!(
+    benches,
+    serde::criterion_benchmark,
+    edn::criterion_benchmark
+);
+criterion_main!(benches);
+
+mod serde {
+    use criterion::Criterion;
+    use edn_rs::{map, set};
+    use serde::Serialize;
+    use std::collections::{BTreeMap, BTreeSet};
+
+    pub fn criterion_benchmark(c: &mut Criterion) {
+        c.bench_function("serde", |b| {
+            b.iter(|| serde_json::to_string(&val()).unwrap())
+        });
+    }
+
+    fn val() -> Val {
+        Val {
+            btreemap: map! {"this is a key".to_string() => vec!["with".to_string(), "many".to_string(), "keys".to_string()]},
+            btreeset: set! {3i64, 4i64, 5i64},
+            tuples: (3i32, true, 'd'),
+            foo_vec: vec![Foo { value: 2 }, Foo { value: 3 }],
+        }
+    }
+
+    #[derive(Debug, Clone, Serialize)]
+    struct Val {
+        btreemap: BTreeMap<String, Vec<String>>,
+        btreeset: BTreeSet<i64>,
+        tuples: (i32, bool, char),
+        foo_vec: Vec<Foo>,
+    }
+
+    #[derive(Debug, Clone, Serialize)]
+    struct Foo {
+        value: usize,
+    }
+}
+
+mod edn {
+    use criterion::Criterion;
+    use edn_derive::Serialize;
+    use edn_rs;
+    use edn_rs::{map, set};
+    use std::collections::{BTreeMap, BTreeSet};
+
+    pub fn criterion_benchmark(c: &mut Criterion) {
+        c.bench_function("edn", |b| b.iter(|| edn_rs::to_string(val())));
+    }
+
+    fn val() -> ValEdn {
+        ValEdn {
+            btreemap: map! {"this is a key".to_string() => vec!["with".to_string(), "many".to_string(), "keys".to_string()]},
+            btreeset: set! {3i64, 4i64, 5i64},
+            tuples: (3i32, true, 'd'),
+            foo_vec: vec![Foo { value: 2 }, Foo { value: 3 }],
+        }
+    }
+
+    #[derive(Debug, Clone, Serialize)]
+    struct ValEdn {
+        btreemap: BTreeMap<String, Vec<String>>,
+        btreeset: BTreeSet<i64>,
+        tuples: (i32, bool, char),
+        foo_vec: Vec<Foo>,
+    }
+
+    #[derive(Debug, Clone, Serialize)]
+    struct Foo {
+        value: usize,
+    }
+}


### PR DESCRIPTION
This Benchmarks are just a loose comparison between `serde_json` and `edn_derive` as it is comparing JSON with EDN, which is way more complex than JSON. This results seem very good for `edn_derive` as it needs to change struct keys.
```
serde_json          time:   [1.7828 us 1.7898 us 1.7967 us]
edn_derive          time:   [8.4526 us 8.4852 us 8.5169 us] 
```