### PR TITLE
Start Trailing spaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edn-rs"
-version = "0.13.3"
+version = "0.13.4"
 authors = ["Julia Naomi <jnboeira@outlook.com>",  "Otavio Pace <otaviopp8@gmail.com>"]
 description = "Crate to parse and emit EDN"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ futures = {version = "0.3.5", optional = true }
 [dev-dependencies]
 tokio = {version = "0.2.22", features = ["macros"] }
 criterion = "0.3"
-edn-derive = "*"
+edn-derive = "0.3.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Current example usage in:
 `Cargo.toml`
 ```toml
 [dependencies]
-edn-rs = "0.13.3"
+edn-rs = "0.13.4"
 ```
 
 ## Simple time-only benchmarks of `edn-rs` agains Clojure Edn
@@ -190,7 +190,7 @@ fn main() -> Result<(), EdnError> {
 ```
 
 **Emits EDN** format from a Json:
-* This function requires feature `json` to be activated. To enable this feature add to your `Cargo.toml`  dependencies the following line `edn-rs = { version = 0.13.3", features = ["json"] }`.
+* This function requires feature `json` to be activated. To enable this feature add to your `Cargo.toml`  dependencies the following line `edn-rs = { version = 0.13.4", features = ["json"] }`.
 
  ```rust
 use edn_rs::json_to_edn;
@@ -226,7 +226,7 @@ fn main() {
 
 ## Using `async/await` with Edn type
 
-Edn supports `futures` by using the feature `async`. To enable this feature add to your `Cargo.toml`  dependencies the following line `edn-rs = { version = 0.13.3", features = ["async"] }` and you can use futures as in the following example.
+Edn supports `futures` by using the feature `async`. To enable this feature add to your `Cargo.toml`  dependencies the following line `edn-rs = { version = 0.13.4", features = ["async"] }` and you can use futures as in the following example.
 
 ```rust
 use edn_rs::{edn, Double, Edn, Vector};
@@ -262,7 +262,7 @@ async fn foo() -> Edn {
 - [x] Define EDN types, `EdnType`
  - [x] Edn Type into primitive: `Edn::Bool(true).into() -> true`. This was done by `to_float`, `to_bool`, `to_int`, `to_vec`.
  - [x] implement `futures::Future` trait to `Edn`
-- [x] Parse EDN data [`from_str`](https://docs.rs/edn-rs/0.13.3/edn_rs/deserialize/fn.from_str.html):
+- [x] Parse EDN data [`from_str`](https://docs.rs/edn-rs/0.13.4/edn_rs/deserialize/fn.from_str.html):
     - [x] nil `""`
     - [x] String `"\"string\""`
     - [x] Numbers `"324352"`, `"3442.234"`, `"3/4"`
@@ -273,7 +273,7 @@ async fn foo() -> Edn {
     - [x] Set `"#{1 2 3}"`
     - [x] Map `"{:a 1 :b 2 }"`
     - [x] Nested structures `"{:a \"2\" :b [true false] :c #{:A {:a :b} nil}}"`
-- [ ] Simple data structures in one another [`edn!`](https://docs.rs/edn-rs/0.13.3/edn_rs/macro.edn.html):
+- [ ] Simple data structures in one another [`edn!`](https://docs.rs/edn-rs/0.13.4/edn_rs/macro.edn.html):
     - [x] Vec in Vec `"[1 2 [:3 \"4\"]]"`
     - [ ] Set in _Vec_ `"[1 2 #{:3 \"4\"}]"`
     - [x] List in List `"(1 2 (:3 \"4\"))"`
@@ -298,7 +298,7 @@ Just add to your `Cargo.toml` the following:
 ```toml
 [dependencies]
 edn-derive = "<version>"
-edn-rs = "0.13.3"
+edn-rs = "0.13.4"
 ```
 
 ### Examples

--- a/src/edn/mod.rs
+++ b/src/edn/mod.rs
@@ -630,7 +630,7 @@ impl std::str::FromStr for Edn {
 
     /// Parses a `&str` that contains an Edn into `Result<Edn, EdnError>`
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let clean = String::from(s.maybe_replace("#{", "@").trim());
+        let clean = String::from(s.maybe_replace("#{", "@").trim_start());
         let mut tokens = parse::tokenize(&clean);
         let edn = parse::parse(tokens.next(), &mut tokens)?;
         Ok(edn)

--- a/src/edn/mod.rs
+++ b/src/edn/mod.rs
@@ -630,7 +630,7 @@ impl std::str::FromStr for Edn {
 
     /// Parses a `&str` that contains an Edn into `Result<Edn, EdnError>`
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let clean = String::from(s.maybe_replace("#{", "@"));
+        let clean = String::from(s.maybe_replace("#{", "@").trim());
         let mut tokens = parse::tokenize(&clean);
         let edn = parse::parse(tokens.next(), &mut tokens)?;
         Ok(edn)


### PR DESCRIPTION
`cargo run --example struct_from_str`
 returns
`Error: ParseEdn("  could not be parsed")`