### PR TITLE
edn_rs::Edn.to_json() method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - checkout
       - run:
           name: Run unit tests
-          command: cargo test  --no-fail-fast --lib
+          command: cargo test  --no-fail-fast --lib --features "json"
 
   test-integration:
     docker:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edn-rs"
-version = "0.16.6"
+version = "0.16.7"
 authors = ["Julia Naomi <jnboeira@outlook.com>",  "Otavio Pace <otaviopp8@gmail.com>"]
 description = "Crate to parse and emit EDN"
 readme = "README.md"
@@ -19,13 +19,13 @@ json = ["regex"]
 [dependencies]
 regex = {version = "1", optional = true }
 futures = {version = "0.3.5", optional = true }
-edn-derive = "0.5.0"
 
 [dev-dependencies]
 tokio = {version = "0.2.22", features = ["macros"] }
 criterion = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+edn-derive = "0.5.0"
 
 [dev-dependencies.cargo-husky]
 version = "1"
@@ -50,4 +50,8 @@ required-features = ["async"]
 
 [[example]]
 name = "json_to_edn"
+required-features = ["json"]
+
+[[example]]
+name = "edn_to_json"
 required-features = ["json"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ json = ["regex"]
 [dependencies]
 regex = {version = "1", optional = true }
 futures = {version = "0.3.5", optional = true }
+edn-derive = "0.5.0"
 
 [dev-dependencies]
 tokio = {version = "0.2.22", features = ["macros"] }
 criterion = "0.3"
-edn-derive = "0.4.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ integration:
 	cargo test --test lib --no-fail-fast --features "json"
 
 unit:
-	cargo test  --no-fail-fast --lib
+	cargo test  --no-fail-fast --lib --features "json"
 
 .PHONY: examples
 examples:

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ unit:
 examples:
 	cargo test --examples --no-fail-fast
 	cargo test --example json_to_edn --features "json"
+	cargo test --example edn_to_json --features "json"
 	cargo run --example async --features "async"
 
 doc-tests:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Current example usage in:
 `Cargo.toml`
 ```toml
 [dependencies]
-edn-rs = "0.16.6"
+edn-rs = "0.16.7"
 ```
 
 ## Simple time-only benchmarks of `edn-rs` agains Clojure Edn
@@ -249,7 +249,7 @@ fn main() -> Result<(), EdnError> {
 ```
 
 **Emits EDN** format from a Json:
-* This function requires feature `json` to be activated. To enable this feature add to your `Cargo.toml`  dependencies the following line `edn-rs = { version = 0.16.6", features = ["json"] }`.
+* This function requires feature `json` to be activated. To enable this feature add to your `Cargo.toml`  dependencies the following line `edn-rs = { version = 0.16.7", features = ["json"] }`.
 
  ```rust
 use edn_rs::json_to_edn;
@@ -321,7 +321,7 @@ fn complex_ok() -> Result<(), EdnError> {
 
 ## Using `async/await` with Edn type
 
-Edn supports `futures` by using the feature `async`. To enable this feature add to your `Cargo.toml`  dependencies the following line `edn-rs = { version = 0.16.6", features = ["async"] }` and you can use futures as in the following example.
+Edn supports `futures` by using the feature `async`. To enable this feature add to your `Cargo.toml`  dependencies the following line `edn-rs = { version = 0.16.7", features = ["async"] }` and you can use futures as in the following example.
 
 ```rust
 use edn_rs::{edn, Double, Edn, Vector};
@@ -359,7 +359,7 @@ async fn foo() -> Edn {
     - [x] implement `futures::Future` trait to `Edn`
     - [x] `to_string()` for `Edn`.
     - [x] `to_debug()` for `Edn`.
-- [x] Parse EDN data [`from_str`](https://docs.rs/edn-rs/0.16.6/edn_rs/deserialize/fn.from_str.html):
+- [x] Parse EDN data [`from_str`](https://docs.rs/edn-rs/0.16.7/edn_rs/deserialize/fn.from_str.html):
     - [x] nil `""`
     - [x] String `"\"string\""`
     - [x] Numbers `"324352"`, `"3442.234"`, `"3/4"`
@@ -371,7 +371,7 @@ async fn foo() -> Edn {
     - [x] Map `"{:a 1 :b 2 }"`
     - [x] Inst `#inst \"yyyy-mm-ddTHH:MM:ss\"`
     - [x] Nested structures `"{:a \"2\" :b [true false] :c #{:A {:a :b} nil}}"`
-- [ ] Simple data structures in one another [`edn!`](https://docs.rs/edn-rs/0.16.6/edn_rs/macro.edn.html):
+- [ ] Simple data structures in one another [`edn!`](https://docs.rs/edn-rs/0.16.7/edn_rs/macro.edn.html):
     - [x] Vec in Vec `"[1 2 [:3 \"4\"]]"`
     - [ ] Set in _Vec_ `"[1 2 #{:3 \"4\"}]"`
     - [x] List in List `"(1 2 (:3 \"4\"))"`
@@ -397,7 +397,7 @@ Just add to your `Cargo.toml` the following:
 ```toml
 [dependencies]
 edn-derive = "<version>"
-edn-rs = "0.16.6"
+edn-rs = "0.16.7"
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -108,25 +108,26 @@ fn main() {
 }
 ```
 
-**Serializes Rust Types into EDN with `ser_struct!`** or use `edn-derive::Serialize`
+**Serializes Rust Types into EDN with `edn-derive::Serialize`**
  ```rust
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use edn_rs::{
-    ser_struct, map, set, hmap, hset
+     map, set, hmap, hset
 };
+use edn_derive::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+struct Edn {
+    btreemap: BTreeMap<String, Vec<String>>,
+    btreeset: BTreeSet<i64>,
+    hashmap: HashMap<String, Vec<String>>,
+    hashset: HashSet<i64>,
+    tuples: (i32, bool, char),
+    nothing: (),
+}
 
 fn main() {
-    ser_struct!{
-        #[derive(Debug, Clone)]
-        struct Edn {
-            btreemap: BTreeMap<String, Vec<String>>,
-            btreeset: BTreeSet<i64>,
-            hashmap: HashMap<String, Vec<String>>,
-            hashset: HashSet<i64>,
-            tuples: (i32, bool, char),
-            nothing: (),
-        }
-    };
+    
     let edn = Edn {
         btreemap: map!{"this is a key".to_string() => vec!["with".to_string(), "many".to_string(), "keys".to_string()]},
         btreeset: set!{3i64, 4i64, 5i64},

--- a/README.md
+++ b/README.md
@@ -283,6 +283,38 @@ fn main() {
 }
  ```
 
+ **Emits a JSON** from type `edn_rs::Edn`.
+ * The associated emthod is `to_json(&self)` and it requires feature `json` to be activated. To enable this feature add to your `Cargo.toml`  dependencies the following line `edn-rs = { version = 0.16.7", features = ["json"] }`.
+ 
+```rust
+use std::str::FromStr;
+fn complex_json() {
+    let edn = "{ 
+        :people-list [ 
+            { :first-name \"otavio\", :age 22 }, 
+            { :first-name \"Julia\", :age 32.0 } 
+        ], 
+        :country-or-origin \"Brazil\", 
+        :queerentener true, 
+        :brain nil }";
+    let parsed_edn : edn_rs::Edn = edn_rs::Edn::from_str(edn).unwrap();
+    let actual_json = parsed_edn.to_json();
+    let expected = String::from(
+        "{\"brain\": null, 
+          \"countryOrOrigin\": \"Brazil\", 
+          \"peopleList\": [
+              {\"age\": 22, \"firstName\": \"otavio\"}, 
+              {\"age\": 32.0, \"firstName\": \"Julia\"}
+            ], 
+          \"queerentener\": true}",
+    );
+    assert_eq!(
+        actual_json,
+        expected
+    );
+}
+```
+
 **to_string/to_debug**
 
 `to_debug` emits a Debug version of `Edn` type.

--- a/examples/edn_to_json.rs
+++ b/examples/edn_to_json.rs
@@ -1,0 +1,21 @@
+use std::str::FromStr;
+
+fn complex_json() {
+    let complex_json = String::from(
+        "{\"brain\": null, \"countryOrOrigin\": \"Brazil\", \"peopleList\": [{\"age\": 22, \"firstName\": \"otavio\"}, {\"age\": 32.0, \"firstName\": \"Julia\"}], \"queerentener\": true}",
+    );
+    let edn = "{ :people-list  [ { :first-name \"otavio\", :age 22 }, { :first-name \"Julia\", :age 32.0 } ], :country-or-origin \"Brazil\", :queerentener true, :brain nil }";
+    let parsed_edn: edn_rs::Edn = edn_rs::Edn::from_str(edn).unwrap();
+    let actual_json = parsed_edn.to_json();
+
+    assert_eq!(actual_json, complex_json);
+}
+
+fn main() {
+    complex_json();
+}
+
+#[test]
+fn test_complex_json() {
+    complex_json();
+}

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -1,24 +1,21 @@
-use edn_rs::{hmap, hset, map, ser_struct, set, Serialize};
+use edn_derive::Serialize;
+use edn_rs::{hmap, hset, map, set};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
-ser_struct! {
-#[derive(Debug, Clone)]
-    struct Foo {
-        value: usize,
-    }
+#[derive(Debug, Clone, Serialize)]
+struct Foo {
+    value: usize,
 }
 
-ser_struct! {
-    #[derive(Debug, Clone)]
-    struct Edn {
-        btreemap: BTreeMap<String, Vec<String>>,
-        btreeset: BTreeSet<i64>,
-        hashmap: HashMap<String, Vec<String>>,
-        hashset: HashSet<i64>,
-        tuples: (i32, bool, char),
-        foo_vec: Vec<Foo>,
-        nothing: (),
-    }
+#[derive(Debug, Clone, Serialize)]
+struct Edn {
+    btreemap: BTreeMap<String, Vec<String>>,
+    btreeset: BTreeSet<i64>,
+    hashmap: HashMap<String, Vec<String>>,
+    hashset: HashSet<i64>,
+    tuples: (i32, bool, char),
+    foo_vec: Vec<Foo>,
+    nothing: (),
 }
 
 fn serialize() -> String {

--- a/src/edn/mod.rs
+++ b/src/edn/mod.rs
@@ -697,7 +697,7 @@ where
     format!("{:?}", i).parse::<f64>()
 }
 
-fn rational_to_double(r: &str) -> Option<f64> {
+pub(crate) fn rational_to_double(r: &str) -> Option<f64> {
     if r.split('/').count() == 2 {
         let vals = r
             .split('/')

--- a/src/edn/mod.rs
+++ b/src/edn/mod.rs
@@ -688,9 +688,9 @@ impl Edn {
         }
     }
 
-    // #[cfg(feature = "json")]
-    pub fn to_json(self) -> String {
-        crate::json::to_json(self)
+    #[cfg(feature = "json")]
+    pub fn to_json(&self) -> String {
+        crate::json::display_as_json(self)
     }
 }
 

--- a/src/edn/mod.rs
+++ b/src/edn/mod.rs
@@ -671,6 +671,11 @@ impl Edn {
             _ => None,
         }
     }
+
+    // #[cfg(feature = "json")]
+    pub fn to_json(self) -> String {
+        crate::json::to_json(self)
+    }
 }
 
 impl std::str::FromStr for Edn {

--- a/src/edn/mod.rs
+++ b/src/edn/mod.rs
@@ -156,6 +156,10 @@ impl Map {
     pub fn empty() -> Map {
         Map(BTreeMap::new())
     }
+
+    pub fn to_map(self) -> BTreeMap<String, Edn> {
+        self.0
+    }
 }
 
 #[cfg(feature = "async")]

--- a/src/edn/mod.rs
+++ b/src/edn/mod.rs
@@ -688,6 +688,43 @@ impl Edn {
         }
     }
 
+    /// Method `to_json` allows you to convert a `edn_rs::Edn` into a JSON string. Type convertions are:
+    /// `Edn::Vector(v)` => a vector like `[value1, value2, ..., valueN]`
+    /// `Edn::Set(s)` => a vector like `[value1, value2, ..., valueN]`
+    /// `Edn::Map(map)` => a map like `{\"key1\": value1, ..., \"keyN\": valueN}`
+    /// `Edn::List(l)` => a vector like `[value1, value2, ..., valueN]`
+    /// `Edn::Key(key)` => a `camelCase` version of the `:kebab-case` keyword,
+    /// `Edn::Symbol(s)` => `\"a-simple-string\"`
+    /// `Edn::Str(s)` => `\"a simple string\"`
+    /// `Edn::Int(n)` => a number like `5`
+    /// `Edn::UInt(n)` => a number like `5`
+    /// `Edn::Double(n)` => a number like `3.14`
+    /// `Edn::Rational(r)` => a number like `0.25` for `1/4`.
+    /// `Edn::Char(c)` => a simple char `\'c\'`
+    /// `Edn::Bool(b)` => boolean options, `true` and `false`
+    /// `Edn::Inst(inst)` => a DateTime string like `\"2020-10-21T00:00:00.000-00:00\"`
+    /// `Edn::Uuid(uuid)` => a UUID string like `\"7a6b6722-0221-4280-865e-ad41060d53b2\"`
+    /// `Edn::NamespacedMap(ns, map)` => a namespaced map like `{\"nameSpace\": {\"key1\": value1, ..., \"keyN\": valueN}}`
+    /// `Edn::Nil` => `null`
+    /// `Edn::Empty` => empty value, ` `
+    /// ```
+    /// use std::str::FromStr;
+    ///
+    /// fn complex_json() {
+    ///     let edn = "{ :people-list  [ { :first-name \"otavio\", :age 22 }, { :first-name \"Julia\", :age 32.0 } ], :country-or-origin \"Brazil\", :queerentener true, :brain nil }";
+    ///     let parsed_edn : edn_rs::Edn = edn_rs::Edn::from_str(edn).unwrap();
+    ///     let actual_json = parsed_edn.to_json();
+    ///
+    ///     let expected = String::from(
+    ///         "{\"brain\": null, \"countryOrOrigin\": \"Brazil\", \"peopleList\": [{\"age\": 22, \"firstName\": \"otavio\"}, {\"age\": 32.0, \"firstName\": \"Julia\"}], \"queerentener\": true}",
+    ///     );
+    ///
+    ///     assert_eq!(
+    ///         actual_json,
+    ///         expected
+    ///     );
+    /// }
+    /// ```
     #[cfg(feature = "json")]
     pub fn to_json(&self) -> String {
         crate::json::display_as_json(self)

--- a/src/edn/mod.rs
+++ b/src/edn/mod.rs
@@ -63,6 +63,10 @@ impl Vector {
     pub fn empty() -> Vector {
         Vector(Vec::new())
     }
+
+    pub fn to_vec(self) -> Vec<Edn> {
+        self.0
+    }
 }
 
 #[cfg(feature = "async")]
@@ -90,6 +94,10 @@ impl List {
     pub fn empty() -> List {
         List(Vec::new())
     }
+
+    pub fn to_vec(self) -> Vec<Edn> {
+        self.0
+    }
 }
 
 #[cfg(feature = "async")]
@@ -116,6 +124,10 @@ impl Set {
 
     pub fn empty() -> Set {
         Set(BTreeSet::new())
+    }
+
+    pub fn to_set(self) -> BTreeSet<Edn> {
+        self.0
     }
 }
 

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -17,8 +17,8 @@ pub(crate) fn display_as_json(edn: &Edn) -> String {
         Edn::UInt(n) => format!("{}", n),
         Edn::Double(n) => format!("{}", n),
         Edn::Rational(r) => format!("{}", rational_to_double(r).unwrap()),
-        Edn::Char(_) => unimplemented!(),
-        Edn::Bool(_) => unimplemented!(),
+        Edn::Char(c) => format!("'{}'", c),
+        Edn::Bool(b) => format!("{}", b),
         Edn::Inst(_) => unimplemented!(),
         Edn::Uuid(_) => unimplemented!(),
         Edn::NamespacedMap(_, _) => unimplemented!(),
@@ -58,5 +58,17 @@ mod test {
             display_as_json(&Edn::Rational("-3/9".to_string())),
             String::from("-0.3333333333333333")
         );
+    }
+
+    #[test]
+    fn bools() {
+        assert_eq!(display_as_json(&Edn::Bool(true)), String::from("true"));
+        assert_eq!(display_as_json(&Edn::Bool(false)), String::from("false"));
+    }
+
+    #[test]
+    fn chars() {
+        assert_eq!(display_as_json(&Edn::Char('e')), String::from("'e'"));
+        assert_eq!(display_as_json(&Edn::Char('5')), String::from("'5'"));
     }
 }

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -1,8 +1,4 @@
-use crate::edn::{rational_to_double, Edn, Vector};
-
-pub(crate) fn to_json(edn: Edn) -> String {
-    String::new()
-}
+use crate::edn::{rational_to_double, Edn};
 
 pub(crate) fn display_as_json(edn: &Edn) -> String {
     match edn {

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -10,8 +10,8 @@ pub(crate) fn display_as_json(edn: &Edn) -> String {
         Edn::Set(_) => unimplemented!(),
         Edn::Map(_) => unimplemented!(),
         Edn::List(_) => unimplemented!(),
-        Edn::Key(_) => unimplemented!(),
-        Edn::Symbol(_) => unimplemented!(),
+        Edn::Key(key) => kebab_to_camel(key),
+        Edn::Symbol(s) => format!("{:?}", s),
         Edn::Str(s) => format!("{:?}", s),
         Edn::Int(n) => format!("{}", n),
         Edn::UInt(n) => format!("{}", n),
@@ -25,6 +25,33 @@ pub(crate) fn display_as_json(edn: &Edn) -> String {
         Edn::Nil => String::from("null"),
         Edn::Empty => String::from(""),
     }
+}
+
+fn kebab_to_camel(key: &str) -> String {
+    let keywrod = key
+        .chars()
+        .enumerate()
+        .map(|(i, c)| {
+            if c == ':' {
+                ' '
+            } else if i > 0 {
+                if &key[i - 1..i] == ":" || &key[i - 1..i] == "-" || &key[i - 1..i] == "." {
+                    c.to_uppercase()
+                        .collect::<String>()
+                        .chars()
+                        .take(1)
+                        .next()
+                        .unwrap()
+                } else {
+                    c
+                }
+            } else {
+                c
+            }
+        })
+        .collect::<String>();
+
+    keywrod.trim().replace("-", "").replace(".", "")
 }
 
 #[cfg(test)]
@@ -91,5 +118,18 @@ mod test {
     fn strings() {
         let edn = Edn::Str("Hello World".to_string());
         assert_eq!(display_as_json(&edn), "\"Hello World\"".to_string());
+    }
+
+    #[test]
+    fn symbols() {
+        let edn = Edn::Symbol("Hello World".to_string());
+        assert_eq!(display_as_json(&edn), "\"Hello World\"".to_string());
+    }
+
+    #[test]
+    fn keyword() {
+        // Don't know what to do with '/'. maybe whitespace?
+        let edn = Edn::Key(":hellow-world/again.id".to_string());
+        assert_eq!(display_as_json(&edn), "HellowWorld/againId".to_string());
     }
 }

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -12,15 +12,15 @@ pub(crate) fn display_as_json(edn: &Edn) -> String {
         Edn::List(_) => unimplemented!(),
         Edn::Key(_) => unimplemented!(),
         Edn::Symbol(_) => unimplemented!(),
-        Edn::Str(_) => unimplemented!(),
+        Edn::Str(s) => format!("{:?}", s),
         Edn::Int(n) => format!("{}", n),
         Edn::UInt(n) => format!("{}", n),
         Edn::Double(n) => format!("{}", n),
         Edn::Rational(r) => format!("{}", rational_to_double(r).unwrap()),
         Edn::Char(c) => format!("'{}'", c),
         Edn::Bool(b) => format!("{}", b),
-        Edn::Inst(_) => unimplemented!(),
-        Edn::Uuid(_) => unimplemented!(),
+        Edn::Inst(inst) => format!("{:?}", inst),
+        Edn::Uuid(uuid) => format!("{:?}", uuid),
         Edn::NamespacedMap(_, _) => unimplemented!(),
         Edn::Nil => String::from("null"),
         Edn::Empty => String::from(""),
@@ -70,5 +70,26 @@ mod test {
     fn chars() {
         assert_eq!(display_as_json(&Edn::Char('e')), String::from("'e'"));
         assert_eq!(display_as_json(&Edn::Char('5')), String::from("'5'"));
+    }
+
+    #[test]
+    fn inst_and_uuid() {
+        let inst = Edn::Inst("2020-09-18T01:16:25.909-00:00".to_string());
+        let uuid = Edn::Uuid("af6d8699-f442-4dfd-8b26-37d80543186b".to_string());
+
+        assert_eq!(
+            display_as_json(&inst),
+            "\"2020-09-18T01:16:25.909-00:00\"".to_string()
+        );
+        assert_eq!(
+            display_as_json(&uuid),
+            "\"af6d8699-f442-4dfd-8b26-37d80543186b\"".to_string()
+        );
+    }
+
+    #[test]
+    fn strings() {
+        let edn = Edn::Str("Hello World".to_string());
+        assert_eq!(display_as_json(&edn), "\"Hello World\"".to_string());
     }
 }

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -1,0 +1,50 @@
+use crate::edn::Edn;
+
+pub(crate) fn to_json(edn: Edn) -> String {
+    String::new()
+}
+
+pub(crate) fn display_as_json(edn: &Edn) -> String {
+    match edn {
+        Edn::Vector(_) => unimplemented!(),
+        Edn::Set(_) => unimplemented!(),
+        Edn::Map(_) => unimplemented!(),
+        Edn::List(_) => unimplemented!(),
+        Edn::Key(_) => unimplemented!(),
+        Edn::Symbol(_) => unimplemented!(),
+        Edn::Str(_) => unimplemented!(),
+        Edn::Int(n) => format!("{}", n),
+        Edn::UInt(n) => format!("{}", n),
+        Edn::Double(n) => format!("{}", n),
+        Edn::Rational(_) => unimplemented!(),
+        Edn::Char(_) => unimplemented!(),
+        Edn::Bool(_) => unimplemented!(),
+        Edn::Inst(_) => unimplemented!(),
+        Edn::Uuid(_) => unimplemented!(),
+        Edn::NamespacedMap(_, _) => unimplemented!(),
+        Edn::Nil => String::from("null"),
+        Edn::Empty => String::from(""),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::edn::Edn;
+
+    #[test]
+    fn nil_and_empty_edns() {
+        assert_eq!(display_as_json(&Edn::Nil), String::from("null"));
+        assert_eq!(display_as_json(&Edn::Empty), String::from(""));
+    }
+
+    #[test]
+    fn numbers() {
+        assert_eq!(display_as_json(&Edn::UInt(34usize)), String::from("34"));
+        assert_eq!(display_as_json(&Edn::Int(-25isize)), String::from("-25"));
+        assert_eq!(
+            display_as_json(&Edn::Double(3.14f64.into())),
+            String::from("3.14")
+        );
+    }
+}

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -1,4 +1,4 @@
-use crate::edn::Edn;
+use crate::edn::{rational_to_double, Edn};
 
 pub(crate) fn to_json(edn: Edn) -> String {
     String::new()
@@ -16,7 +16,7 @@ pub(crate) fn display_as_json(edn: &Edn) -> String {
         Edn::Int(n) => format!("{}", n),
         Edn::UInt(n) => format!("{}", n),
         Edn::Double(n) => format!("{}", n),
-        Edn::Rational(_) => unimplemented!(),
+        Edn::Rational(r) => format!("{}", rational_to_double(r).unwrap()),
         Edn::Char(_) => unimplemented!(),
         Edn::Bool(_) => unimplemented!(),
         Edn::Inst(_) => unimplemented!(),
@@ -45,6 +45,18 @@ mod test {
         assert_eq!(
             display_as_json(&Edn::Double(3.14f64.into())),
             String::from("3.14")
+        );
+    }
+
+    #[test]
+    fn rational_numbers() {
+        assert_eq!(
+            display_as_json(&Edn::Rational("3/4".to_string())),
+            String::from("0.75")
+        );
+        assert_eq!(
+            display_as_json(&Edn::Rational("-3/9".to_string())),
+            String::from("-0.3333333333333333")
         );
     }
 }

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -59,7 +59,7 @@ fn vec_to_json(vec: Vec<Edn>) -> String {
         .iter()
         .map(|e| display_as_json(e))
         .collect::<Vec<String>>()
-        .join(",");
+        .join(", ");
     let mut s = String::from("[");
     s.push_str(&vec_str);
     s.push_str("]");
@@ -71,7 +71,7 @@ fn set_to_json_vec(set: std::collections::BTreeSet<Edn>) -> String {
         .iter()
         .map(|e| display_as_json(e))
         .collect::<Vec<String>>()
-        .join(",");
+        .join(", ");
     let mut s = String::from("[");
     s.push_str(&set_str);
     s.push_str("]");
@@ -171,7 +171,7 @@ mod test {
         ]));
         assert_eq!(
             display_as_json(&edn),
-            "[true,\"b\",\"test\",\'4\',-0.75,4.5,4]".to_string()
+            "[true, \"b\", \"test\", \'4\', -0.75, 4.5, 4]".to_string()
         );
     }
 
@@ -188,7 +188,7 @@ mod test {
         ]));
         assert_eq!(
             display_as_json(&edn),
-            "[true,\"b\",\"test\",\'4\',-0.75,4.5,4]".to_string()
+            "[true, \"b\", \"test\", \'4\', -0.75, 4.5, 4]".to_string()
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,9 @@ pub mod edn;
 ///```
 pub mod serialize;
 
+// #[cfg(feature = "json")]
+pub(crate) mod json;
+
 mod deserialize;
 /// `json_to_edn` receives a json string and parses its common key-values to a regular EDN format. It requires feature `json`
 /// tested examples are:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,20 +14,19 @@ pub mod edn;
 ///
 /// Example:
 /// ```rust
-/// #[macro_use] extern crate edn_rs;
 ///
 /// use std::collections::{BTreeMap, BTreeSet};
-/// use crate::edn_rs::Serialize;
+/// use edn_derive::Serialize;
+/// use edn_rs::{map, set};
+///
+/// #[derive(Debug, Serialize)]
+/// struct Edn {
+///     map: BTreeMap<String, Vec<String>>,
+///     set: BTreeSet<i64>,
+///     tuples: (i32, bool, char),
+/// }
 ///
 /// fn main() {
-///     ser_struct!{
-///         #[derive(Debug)]
-///         struct Edn {
-///             map: BTreeMap<String, Vec<String>>,
-///             set: BTreeSet<i64>,
-///             tuples: (i32, bool, char),
-///         }
-///     };
 ///     let edn = Edn {
 ///         map: map!{"this is a key".to_string() => vec!["with".to_string(), "many".to_string(), "keys".to_string()]},
 ///         set: set!{3i64, 4i64, 5i64},
@@ -82,25 +81,23 @@ pub use serialize::Serialize;
 
 /// Function for converting Rust types into EDN Strings.
 /// For it to work, the type must implement the Serialize trait.
-/// For now you can do it via `ser_struct!` macro, in the future
-/// it will be via `#[derive(Serialize)]` from `edn-derive` crate.
+/// It is possible to implement the `Serialize` from `edn-derive` crate.
 ///
 /// Example:
 /// ```rust
-/// #[macro_use] extern crate edn_rs;
-///
 /// use std::collections::{BTreeMap, BTreeSet};
-/// use crate::edn_rs::Serialize;
+/// use edn_derive::Serialize;
+/// use edn_rs::{map, set};
+///
+/// #[derive(Debug, Serialize)]
+/// struct Edn {
+///     map: BTreeMap<String, Vec<String>>,
+///     set: BTreeSet<i64>,
+///     tuples: (i32, bool, char),
+/// }
 ///
 /// fn main() {
-///     ser_struct!{
-///         #[derive(Debug)]
-///         struct Edn {
-///             map: BTreeMap<String, Vec<String>>,
-///             set: BTreeSet<i64>,
-///             tuples: (i32, bool, char),
-///         }
-///     };
+///
 ///     let edn = Edn {
 ///         map: map!{"this is a key".to_string() => vec!["with".to_string(), "many".to_string(), "keys".to_string()]},
 ///         set: set!{3i64, 4i64, 5i64},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub mod edn;
 ///```
 pub mod serialize;
 
-// #[cfg(feature = "json")]
+#[cfg(feature = "json")]
 pub(crate) mod json;
 
 mod deserialize;

--- a/tests/emit.rs
+++ b/tests/emit.rs
@@ -90,4 +90,43 @@ mod tests {
         let a: Result<A, EdnError> = edn_rs::from_str("{ :amount \"123\" }");
         assert_eq!(a, Ok(A { amount: 123 }));
     }
+
+    #[test]
+    fn to_json() {
+        use edn_rs::edn::{Edn, List, Map, Set, Vector};
+        use edn_rs::{map, set};
+
+        let edn = Edn::Vector(Vector::new(vec![
+            Edn::Int(1),
+            Edn::Double(1.2.into()),
+            Edn::UInt(3),
+            Edn::List(List::new(vec![
+                Edn::Bool(false),
+                Edn::Key(":f".to_string()),
+                Edn::Nil,
+                Edn::Rational("3/4".to_string()),
+                Edn::Set(Set::new(set! {
+                    Edn::Rational("3/4".to_string())
+                })),
+            ])),
+            Edn::Map(Map::new(map![
+                    String::from("false") => Edn::Key(":f".to_string()),
+                    String::from("nil") => Edn::Rational("3/4".to_string()),
+                    String::from(":my-crazy-map") => Edn::Map(Map::new(map![
+                        String::from("false") => Edn::Map(
+                            Map::new( map![
+                                String::from(":f") => Edn::Key(String::from(":b"))
+                            ])),
+                        String::from("nil") => Edn::Vector(
+                            Vector::new( vec![
+                                Edn::Rational("3/4".to_string()),
+                                Edn::Int(1isize)
+                            ]))
+                ]))
+            ])),
+        ]));
+
+        assert_eq!(edn.to_json(),
+            "[1, 1.2, 3, [false, \"f\", null, 0.75, [0.75]], {\"myCrazyMap\": {\"false\": {\"f\": \"b\"}, \"nil\": [0.75, 1]}, \"false\": \"f\", \"nil\": 0.75}]");
+    }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,8 @@
 #![recursion_limit = "512"]
 
 extern crate edn_rs;
-
+#[macro_use()]
+extern crate edn_derive;
 pub mod emit;
 pub mod parse;
 pub mod ser;

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -1,21 +1,21 @@
 #[cfg(test)]
 mod tests {
+    use edn_derive::Serialize;
     use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
-    use edn_rs::{hmap, hset, map, ser_struct, serialize::Serialize, set};
+    use edn_rs::{hmap, hset, map, set};
 
     #[test]
     fn serializes_a_complex_structure() {
-        ser_struct! {
-            #[derive(Debug, Clone)]
-            struct Example {
-                btreemap: BTreeMap<String, Vec<String>>,
-                btreeset: BTreeSet<i64>,
-                hashmap: HashMap<String, Vec<String>>,
-                hashset: HashSet<i64>,
-                tuples: (i32, bool, char),
-            }
-        };
+        #[derive(Debug, Clone, Serialize)]
+        struct Example {
+            btreemap: BTreeMap<String, Vec<String>>,
+            btreeset: BTreeSet<i64>,
+            hashmap: HashMap<String, Vec<String>>,
+            hashset: HashSet<i64>,
+            tuples: (i32, bool, char),
+        }
+
         let edn = Example {
             btreemap: map! {"this is a key".to_string() => vec!["with".to_string(), "many".to_string(), "keys".to_string()]},
             btreeset: set! {3i64, 4i64, 5i64},
@@ -24,32 +24,26 @@ mod tests {
             tuples: (3i32, true, 'd'),
         };
 
-        assert_eq!(edn.serialize(), "{ :btreemap {:this-is-a-key [\"with\", \"many\", \"keys\"]}, :btreeset #{3, 4, 5}, :hashmap {:this-is-a-key [\"with\", \"many\", \"keys\"]}, :hashset #{3}, :tuples (3, true, \\d), }");
+        assert_eq!(edn_rs::to_string(edn), "{ :btreemap {:this-is-a-key [\"with\", \"many\", \"keys\"]}, :btreeset #{3, 4, 5}, :hashmap {:this-is-a-key [\"with\", \"many\", \"keys\"]}, :hashset #{3}, :tuples (3, true, \\d), }");
     }
 
     #[test]
     fn serializes_nested_structures() {
-        ser_struct! {
-        #[derive(Debug, Clone)]
+        #[derive(Debug, Clone, Serialize)]
         struct Foo {
             value: bool,
         }
-        }
 
-        ser_struct! {
-        #[derive(Debug, Clone)]
+        #[derive(Debug, Clone, Serialize)]
         struct Bar {
             value: String,
             foo_vec: Vec<Foo>,
         }
-        }
 
-        ser_struct! {
-        #[derive(Debug, Clone)]
+        #[derive(Debug, Clone, Serialize)]
         struct FooBar {
             value: f64,
             bar: Bar,
-        }
         }
 
         let edn = FooBar {
@@ -60,29 +54,6 @@ mod tests {
             },
         };
 
-        assert_eq!(edn.serialize(), "{ :value 3.4, :bar { :value \"data\", :foo-vec [{ :value false, }, { :value true, }], }, }");
-    }
-}
-
-#[test]
-fn pub_struct() {
-    let edn = helper::Edn {
-        val: 6i32,
-        tuples: (3i32, true, 'd'),
-    };
-
-    assert_eq!(edn.val, 6i32);
-    assert_eq!(edn.tuples, (3i32, true, 'd'));
-}
-
-mod helper {
-    use edn_rs::{ser_struct, serialize::Serialize};
-
-    ser_struct! {
-        #[derive(Debug, Clone)]
-        pub struct Edn {
-            val: i32,
-            tuples: (i32, bool, char),
-        }
+        assert_eq!(edn_rs::to_string(edn), "{ :value 3.4, :bar { :value \"data\", :foo-vec [{ :value false, }, { :value true, }], }, }");
     }
 }


### PR DESCRIPTION
 Method `to_json` allows you to convert a `edn_rs::Edn` into a JSON string. requires feature `json`. Type convertions are:
 `Edn::Vector(v)` => a vector like `[value1, value2, ..., valueN]`
 `Edn::Set(s)` => a vector like `[value1, value2, ..., valueN]`
 `Edn::Map(map)` => a map like `{\"key1\": value1, ..., \"keyN\": valueN}`
 `Edn::List(l)` => a vector like `[value1, value2, ..., valueN]`
 `Edn::Key(key)` => a `camelCase` version of the `:kebab-case` keyword,
 `Edn::Symbol(s)` => `\"a-simple-string\"`
 `Edn::Str(s)` => `\"a simple string\"`
 `Edn::Int(n)` => a number like `5`
 `Edn::UInt(n)` => a number like `5`
 `Edn::Double(n)` => a number like `3.14`
 `Edn::Rational(r)` => a number like `0.25` for `1/4`.
 `Edn::Char(c)` => a simple char `\'c\'`
 `Edn::Bool(b)` => boolean options, `true` and `false`
 `Edn::Inst(inst)` => a DateTime string like `\"2020-10-21T00:00:00.000-00:00\"`
 `Edn::Uuid(uuid)` => a UUID string like `\"7a6b6722-0221-4280-865e-ad41060d53b2\"`
 `Edn::NamespacedMap(ns, map)` => a namespaced map like `{\"nameSpace\": {\"key1\": value1, ..., \"keyN\": valueN}}`
 `Edn::Nil` => `null`
 `Edn::Empty` => empty value, ` `

 ```rust
 use std::str::FromStr;

 fn complex_json() {
     let edn = "{ :people-list  [ { :first-name \"otavio\", :age 22 }, { :first-name \"Julia\", :age 32.0 } ], :country-or-origin \"Brazil\", :queerentener true, :brain nil }";
     let parsed_edn : edn_rs::Edn = edn_rs::Edn::from_str(edn).unwrap();
     let actual_json = parsed_edn.to_json();

     let expected = String::from(
         "{\"brain\": null, \"countryOrOrigin\": \"Brazil\", \"peopleList\": [{\"age\": 22, \"firstName\": \"otavio\"}, {\"age\": 32.0, \"firstName\": \"Julia\"}], \"queerentener\": true}",
     );

     assert_eq!(
         actual_json,
         expected
     );
 }
 ```
    