### PR TITLE
Deserialize for std::collections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edn-rs"
-version = "0.16.7"
+version = "0.16.8"
 authors = ["Julia Naomi <jnboeira@outlook.com>",  "Otavio Pace <otaviopp8@gmail.com>"]
 description = "Crate to parse and emit EDN"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Current example usage in:
 `Cargo.toml`
 ```toml
 [dependencies]
-edn-rs = "0.16.7"
+edn-rs = "0.16.8"
 ```
 
 ## Simple time-only benchmarks of `edn-rs` agains Clojure Edn
@@ -248,7 +248,7 @@ fn main() -> Result<(), EdnError> {
 ```
 
 **Emits EDN** format from a Json:
-* This function requires feature `json` to be activated. To enable this feature add to your `Cargo.toml`  dependencies the following line `edn-rs = { version = 0.16.7", features = ["json"] }`.
+* This function requires feature `json` to be activated. To enable this feature add to your `Cargo.toml`  dependencies the following line `edn-rs = { version = 0.16.8", features = ["json"] }`.
 
  ```rust
 use edn_rs::json_to_edn;
@@ -283,7 +283,7 @@ fn main() {
  ```
 
  **Emits a JSON** from type `edn_rs::Edn`.
- * The associated emthod is `to_json(&self)` and it requires feature `json` to be activated. To enable this feature add to your `Cargo.toml`  dependencies the following line `edn-rs = { version = 0.16.7", features = ["json"] }`.
+ * The associated emthod is `to_json(&self)` and it requires feature `json` to be activated. To enable this feature add to your `Cargo.toml`  dependencies the following line `edn-rs = { version = 0.16.8", features = ["json"] }`.
  
 ```rust
 use std::str::FromStr;
@@ -352,7 +352,7 @@ fn complex_ok() -> Result<(), EdnError> {
 
 ## Using `async/await` with Edn type
 
-Edn supports `futures` by using the feature `async`. To enable this feature add to your `Cargo.toml`  dependencies the following line `edn-rs = { version = 0.16.7", features = ["async"] }` and you can use futures as in the following example.
+Edn supports `futures` by using the feature `async`. To enable this feature add to your `Cargo.toml`  dependencies the following line `edn-rs = { version = 0.16.8", features = ["async"] }` and you can use futures as in the following example.
 
 ```rust
 use edn_rs::{edn, Double, Edn, Vector};
@@ -390,7 +390,7 @@ async fn foo() -> Edn {
     - [x] implement `futures::Future` trait to `Edn`
     - [x] `to_string()` for `Edn`.
     - [x] `to_debug()` for `Edn`.
-- [x] Parse EDN data [`from_str`](https://docs.rs/edn-rs/0.16.7/edn_rs/deserialize/fn.from_str.html):
+- [x] Parse EDN data [`from_str`](https://docs.rs/edn-rs/0.16.8/edn_rs/deserialize/fn.from_str.html):
     - [x] nil `""`
     - [x] String `"\"string\""`
     - [x] Numbers `"324352"`, `"3442.234"`, `"3/4"`
@@ -402,7 +402,7 @@ async fn foo() -> Edn {
     - [x] Map `"{:a 1 :b 2 }"`
     - [x] Inst `#inst \"yyyy-mm-ddTHH:MM:ss\"`
     - [x] Nested structures `"{:a \"2\" :b [true false] :c #{:A {:a :b} nil}}"`
-- [ ] Simple data structures in one another [`edn!`](https://docs.rs/edn-rs/0.16.7/edn_rs/macro.edn.html):
+- [ ] Simple data structures in one another [`edn!`](https://docs.rs/edn-rs/0.16.8/edn_rs/macro.edn.html):
     - [x] Vec in Vec `"[1 2 [:3 \"4\"]]"`
     - [ ] Set in _Vec_ `"[1 2 #{:3 \"4\"}]"`
     - [x] List in List `"(1 2 (:3 \"4\"))"`
@@ -428,7 +428,7 @@ Just add to your `Cargo.toml` the following:
 ```toml
 [dependencies]
 edn-derive = "<version>"
-edn-rs = "0.16.7"
+edn-rs = "0.16.8"
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ fn main() -> Result<(), EdnError> {
 ```
 
 **Deserializes Edn types into Rust Types**:
+* Deserialization to `std::collection::*` is currently unsafe.
 
 > For now you have to implement the conversion yourself with the `Deserialize` trait. Soon you'll be able to have that implemented for you via `edn-derive` crate.
  ```rust


### PR DESCRIPTION
adds `#[deprecated]` to `ser_struct!`