### PR TITLE
Fix an issue with parsing false/true/nil when no ' ' character is following.

### DIFF
--- a/src/deserialize/parse.rs
+++ b/src/deserialize/parse.rs
@@ -1,6 +1,8 @@
 use crate::edn::{Edn, Error, List, Map, Set, Vector};
 use std::collections::{BTreeMap, BTreeSet};
 
+const DELIMITERS: [char; 5] = [',', ']', '}', ')', ';'];
+
 pub(crate) fn tokenize(edn: &str) -> std::iter::Enumerate<std::str::Chars> {
     edn.chars().enumerate()
 }
@@ -262,12 +264,11 @@ fn read_bool_or_nil(
         .next()
         .ok_or_else(|| Error::ParseEdn("Could not identify symbol index".to_string()))?
         .0;
-    let delimiters = [',', ']', '}', ')', ';'];
     match c {
         't' if {
             let val = chars
                 .clone()
-                .take_while(|(_, c)| !c.is_whitespace() && !delimiters.contains(c))
+                .take_while(|(_, c)| !c.is_whitespace() && !DELIMITERS.contains(c))
                 .map(|c| c.1)
                 .collect::<String>();
             val.eq("rue")
@@ -282,7 +283,7 @@ fn read_bool_or_nil(
         'f' if {
             let val = chars
                 .clone()
-                .take_while(|(_, c)| !c.is_whitespace() && !delimiters.contains(c))
+                .take_while(|(_, c)| !c.is_whitespace() && !DELIMITERS.contains(c))
                 .map(|c| c.1)
                 .collect::<String>();
             val.eq("alse")
@@ -297,7 +298,7 @@ fn read_bool_or_nil(
         'n' if {
             let val = chars
                 .clone()
-                .take_while(|(_, c)| !c.is_whitespace() && !delimiters.contains(c))
+                .take_while(|(_, c)| !c.is_whitespace() && !DELIMITERS.contains(c))
                 .map(|c| c.1)
                 .collect::<String>();
             val.eq("il")

--- a/src/deserialize/parse.rs
+++ b/src/deserialize/parse.rs
@@ -262,7 +262,7 @@ fn read_bool_or_nil(
         .next()
         .ok_or_else(|| Error::ParseEdn("Could not identify symbol index".to_string()))?
         .0;
-    let delimiters = [',', ']', '}', ')'];
+    let delimiters = [',', ']', '}', ')', ';'];
     match c {
         't' if {
             let val = chars
@@ -845,6 +845,18 @@ mod test {
                 Edn::Char('c'),
                 Edn::UInt(3)
             ]))
+        )
+    }
+
+    #[test]
+    fn parse_true_false_nil_with_comments_in_set() {
+        let mut edn = "#{true;this is true\nfalse;this is false\nnil;this is nil\n}"
+            .chars()
+            .enumerate();
+
+        assert_eq!(
+            parse(edn.next(), &mut edn).unwrap(),
+            Edn::Set(Set::new(set![Edn::Bool(true), Edn::Bool(false), Edn::Nil,]))
         )
     }
 


### PR DESCRIPTION
true, false, and nil were being parsed as a Symbol if there was no space or delimiter immediately following. Here's the output of the new tests before the fix:
```
failures:

---- deserialize::parse::test::parse_bool_in_crlf_newline_simple_vec_str_literal stdout ----
thread 'deserialize::parse::test::parse_bool_in_crlf_newline_simple_vec_str_literal' panicked at 'assertion failed: `(left == right)`
  left: `Vector(Vector([Symbol("nil"), Symbol("false"), Symbol("true")]))`,
 right: `Vector(Vector([Nil, Bool(false), Bool(true)]))`', src/deserialize/parse.rs:753:9

---- deserialize::parse::test::parse_bool_in_tab_simple_vec_str_literal stdout ----
thread 'deserialize::parse::test::parse_bool_in_tab_simple_vec_str_literal' panicked at 'assertion failed: `(left == right)`
  left: `Vector(Vector([Symbol("true"), Symbol("nil"), Symbol("false")]))`,
 right: `Vector(Vector([Bool(true), Nil, Bool(false)]))`', src/deserialize/parse.rs:741:9

---- deserialize::parse::test::parse_bool_in_newline_simple_vec_str_literal stdout ----
thread 'deserialize::parse::test::parse_bool_in_newline_simple_vec_str_literal' panicked at 'assertion failed: `(left == right)`
  left: `Vector(Vector([Symbol("true"), Symbol("false"), Symbol("nil")]))`,
 right: `Vector(Vector([Bool(true), Bool(false), Nil]))`', src/deserialize/parse.rs:729:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    deserialize::parse::test::parse_bool_in_crlf_newline_simple_vec_str_literal
    deserialize::parse::test::parse_bool_in_newline_simple_vec_str_literal
    deserialize::parse::test::parse_bool_in_tab_simple_vec_str_literal
```

I accidentally found this when my editor was stripping whitespace here https://github.com/naomijub/edn-rs/blob/e74e564afb25a8011fa8437d35bf5e66b5a2eb92/src/deserialize/parse.rs#L704 while navigating about the code base thinking about #100.

On a related note, I'm not able to see anything on CircleCI. There's a few clippy warnings and a lot of formatting things, at least on rust 1.71 using the default rustfmt (1.5.2). Any thoughts on this? Maybe github workflows?