### PR TITLE
Clippy + Format. 

### DIFF
--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use edn_rs;
+
 use std::str::FromStr;
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/benches/serialize.rs
+++ b/benches/serialize.rs
@@ -45,7 +45,7 @@ mod serde {
 mod edn {
     use criterion::Criterion;
     use edn_derive::Serialize;
-    use edn_rs;
+
     use edn_rs::{map, set};
     use std::collections::{BTreeMap, BTreeSet};
 

--- a/benches/tagged_parse.rs
+++ b/benches/tagged_parse.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use edn_rs;
+
 use std::str::FromStr;
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/examples/complex_struct_deserialization.rs
+++ b/examples/complex_struct_deserialization.rs
@@ -36,7 +36,7 @@ fn complex_ok() -> Result<(), EdnError> {
     let edn_str = "{ :list [{:name \"rose\" :age 66 :cool true}, {:name \"josh\" :age 33 :cool false}, {:name \"eva\" :age 296 :cool true}] :nothing nil }";
     let complex: Complex = edn_rs::from_str(edn_str)?;
 
-    println!("{:?}", complex);
+    println!("{complex:?}");
     // Complex { list: [Another { name: "rose", age: 66, cool: true }, Another { name: "josh", age: 33, cool: false }, Another { name: "eva", age: 296, cool: true }] }
 
     assert_eq!(

--- a/examples/edn_from_str.rs
+++ b/examples/edn_from_str.rs
@@ -9,7 +9,7 @@ fn edn_from_str() -> Result<Edn, EdnError> {
 fn main() -> Result<(), EdnError> {
     let edn = edn_from_str()?;
 
-    println!("{:?}", edn);
+    println!("{edn:?}");
 
     Ok(())
 }

--- a/examples/from_edn.rs
+++ b/examples/from_edn.rs
@@ -22,7 +22,7 @@ fn person_ok() -> Result<(), EdnError> {
     }));
     let person: Person = edn_rs::from_edn(&edn)?;
 
-    println!("{:?}", person);
+    println!("{person:?}");
     // Person { name: "rose", age: 66 }
 
     assert_eq!(

--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -2,14 +2,9 @@ use edn_rs::{Edn, Vector};
 
 fn iterator() {
     let v = Edn::Vector(Vector::new(vec![Edn::Int(5), Edn::Int(6), Edn::Int(7)]));
-    let sum = v
-        .iter_some()
-        .unwrap()
-        .filter(|e| e.to_int().is_some())
-        .map(|e| e.to_int().unwrap())
-        .sum();
+    let sum = v.iter_some().unwrap().filter_map(edn_rs::Edn::to_int).sum();
 
-    println!("{:?}", sum);
+    println!("{sum:?}");
     assert_eq!(18isize, sum);
 }
 

--- a/examples/json_to_edn.rs
+++ b/examples/json_to_edn.rs
@@ -31,9 +31,9 @@ fn complex_json() {
 
     assert_eq!(
         edn,
-        json_to_edn(complex_json.clone())
+        json_to_edn(complex_json)
             .replace("  ", "")
-            .replace("\n", " ")
+            .replace('\n', " ")
     );
 }
 

--- a/examples/navigate_edn.rs
+++ b/examples/navigate_edn.rs
@@ -5,7 +5,7 @@ use edn_rs::{
 
 fn navigate() {
     let edn = edn!((sym 1.2 3 {false :f nil 3/4}));
-    println!("{:?}", edn);
+    println!("{edn:?}");
 
     assert_eq!(edn[1], edn!(1.2));
     assert_eq!(edn[1], Edn::Double(1.2f64.into()));

--- a/examples/option_deserialization.rs
+++ b/examples/option_deserialization.rs
@@ -35,7 +35,7 @@ impl Deserialize for Complex {
 fn maybe_is_some() -> Result<(), EdnError> {
     let edn_str = "{ :id 22 :maybe {:name \"rose\" :age 66 :cool true} }";
     let complex: Complex = edn_rs::from_str(edn_str)?;
-    println!("{:?}", complex);
+    println!("{complex:?}");
     // Complex { id: 22, maybe: Another { name: "rose", age: 66, cool: true } }
 
     assert_eq!(
@@ -55,7 +55,7 @@ fn maybe_is_some() -> Result<(), EdnError> {
 fn maybe_is_none() -> Result<(), EdnError> {
     let edn_str = "{ :id 1 }";
     let complex: Complex = edn_rs::from_str(edn_str)?;
-    println!("{:?}", complex);
+    println!("{complex:?}");
     // Complex { id: 1, maybe: None }
 
     assert_eq!(complex, Complex { id: 1, maybe: None });

--- a/examples/struct_from_str.rs
+++ b/examples/struct_from_str.rs
@@ -19,7 +19,7 @@ fn person_ok() -> Result<(), EdnError> {
     let edn_str = "  {:name \"rose\" :age 66  }  ";
     let person: Person = edn_rs::from_str(edn_str)?;
 
-    println!("{:?}", person);
+    println!("{person:?}");
     // Person { name: "rose", age: 66 }
 
     assert_eq!(

--- a/examples/tokenize_edn.rs
+++ b/examples/tokenize_edn.rs
@@ -15,7 +15,7 @@ fn tokenize() {
         Edn::Rational("3/4".to_string()),
     ]));
 
-    println!("{:?}", edn);
+    println!("{edn:?}");
     assert_eq!(edn, expected);
 }
 

--- a/src/edn/utils/mod.rs
+++ b/src/edn/utils/mod.rs
@@ -4,6 +4,8 @@ use regex::{Captures, Regex};
 pub mod index;
 
 #[cfg(feature = "json")]
+#[must_use]
+#[allow(clippy::needless_pass_by_value)]
 pub fn replace_keywords(json: String) -> String {
     let re = Regex::new(r#""\w*(\s\w*)*":"#).unwrap();
 
@@ -16,6 +18,8 @@ pub fn replace_keywords(json: String) -> String {
 }
 
 #[cfg(feature = "json")]
+#[must_use]
+#[allow(clippy::needless_pass_by_value)]
 pub fn replace_char(json: String) -> String {
     let c_re = Regex::new(r#"'.'"#).unwrap();
 
@@ -33,49 +37,49 @@ pub trait Attribute {
 
 impl Attribute for f64 {
     fn process(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 
 impl Attribute for f32 {
     fn process(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 
 impl Attribute for isize {
     fn process(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 
 impl Attribute for i32 {
     fn process(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 
 impl Attribute for i64 {
     fn process(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 
 impl Attribute for usize {
     fn process(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 
 impl Attribute for u64 {
     fn process(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 
 impl Attribute for u32 {
     fn process(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 
@@ -87,6 +91,6 @@ impl Attribute for &str {
 
 impl Attribute for bool {
     fn process(&self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 }

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -1,25 +1,25 @@
 use crate::edn::{rational_to_double, Edn};
 
-pub(crate) fn display_as_json(edn: &Edn) -> String {
+#[allow(clippy::module_name_repetitions)]
+pub fn display_as_json(edn: &Edn) -> String {
     match edn {
-        Edn::Vector(v) => vec_to_json(v.to_owned().to_vec()),
-        Edn::Set(s) => set_to_json_vec(s.to_owned().to_set()),
-        Edn::Map(map) => map_to_json(map.to_owned().to_map()),
-        Edn::List(l) => vec_to_json(l.to_owned().to_vec()),
+        Edn::Vector(v) => vec_to_json(&v.clone().to_vec()),
+        Edn::Set(s) => set_to_json_vec(&s.clone().to_set()),
+        Edn::Map(map) => map_to_json(&map.clone().to_map()),
+        Edn::List(l) => vec_to_json(&l.clone().to_vec()),
         Edn::Key(key) => format!("{:?}", kebab_to_camel(key)),
-        Edn::Symbol(s) => format!("{:?}", s),
-        Edn::Str(s) => format!("{:?}", s),
-        Edn::Int(n) => format!("{}", n),
-        Edn::UInt(n) => format!("{}", n),
-        Edn::Double(n) => format!("{}", n),
+        Edn::Symbol(s) | Edn::Str(s) => format!("{s:?}"),
+        Edn::Int(n) => format!("{n}"),
+        Edn::UInt(n) => format!("{n}"),
+        Edn::Double(n) => format!("{n}"),
         Edn::Rational(r) => format!("{}", rational_to_double(r).unwrap()),
-        Edn::Char(c) => format!("'{}'", c),
-        Edn::Bool(b) => format!("{}", b),
-        Edn::Inst(inst) => format!("{:?}", inst),
-        Edn::Uuid(uuid) => format!("{:?}", uuid),
-        Edn::NamespacedMap(ns, map) => nsmap_to_json(ns, map.to_owned().to_map()),
+        Edn::Char(c) => format!("'{c}'"),
+        Edn::Bool(b) => format!("{b}"),
+        Edn::Inst(inst) => format!("{inst:?}"),
+        Edn::Uuid(uuid) => format!("{uuid:?}"),
+        Edn::NamespacedMap(ns, map) => nsmap_to_json(ns, &map.clone().to_map()),
         Edn::Nil => String::from("null"),
-        Edn::Empty => String::from(""),
+        Edn::Empty => String::new(),
         Edn::Tagged(tag, content) => format!("{{ \"{}\": {}}}", tag, display_as_json(content)),
     }
 }
@@ -51,7 +51,7 @@ fn kebab_to_camel(key: &str) -> String {
     keywrod.trim().replace(['-', '.'], "")
 }
 
-fn vec_to_json(vec: Vec<Edn>) -> String {
+fn vec_to_json(vec: &[Edn]) -> String {
     let vec_str = vec
         .iter()
         .map(display_as_json)
@@ -63,7 +63,7 @@ fn vec_to_json(vec: Vec<Edn>) -> String {
     s
 }
 
-fn set_to_json_vec(set: std::collections::BTreeSet<Edn>) -> String {
+fn set_to_json_vec(set: &std::collections::BTreeSet<Edn>) -> String {
     let set_str = set
         .iter()
         .map(display_as_json)
@@ -75,7 +75,7 @@ fn set_to_json_vec(set: std::collections::BTreeSet<Edn>) -> String {
     s
 }
 
-fn map_to_json(map: std::collections::BTreeMap<String, Edn>) -> String {
+fn map_to_json(map: &std::collections::BTreeMap<String, Edn>) -> String {
     let map_str = map
         .iter()
         .map(|(k, e)| {
@@ -86,7 +86,7 @@ fn map_to_json(map: std::collections::BTreeMap<String, Edn>) -> String {
             };
             let edn = display_as_json(e);
 
-            format!("{:?}: {}", key, edn)
+            format!("{key:?}: {edn}")
         })
         .collect::<Vec<String>>()
         .join(", ");
@@ -96,7 +96,7 @@ fn map_to_json(map: std::collections::BTreeMap<String, Edn>) -> String {
     s
 }
 
-fn nsmap_to_json(ns: &str, map: std::collections::BTreeMap<String, Edn>) -> String {
+fn nsmap_to_json(ns: &str, map: &std::collections::BTreeMap<String, Edn>) -> String {
     let mut s = String::from("{");
     let map_str = map_to_json(map);
     s.push_str(&format!("{:?}: ", kebab_to_camel(ns)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ mod deserialize;
 /// }
 /// ```
 #[cfg(feature = "json")]
+#[must_use]
 pub fn json_to_edn(json: String) -> String {
     use edn::utils::{replace_char, replace_keywords};
     let edn_aux = replace_keywords(json);

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -201,19 +201,19 @@ impl Serialize for () {
 
 impl Serialize for String {
     fn serialize(self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 
 impl Serialize for &str {
     fn serialize(self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 
 impl Serialize for char {
     fn serialize(self) -> String {
-        format!("\\{}", self)
+        format!("\\{self}")
     }
 }
 
@@ -222,11 +222,10 @@ where
     T: Serialize,
 {
     fn serialize(self) -> String {
-        if let Some(t) = self {
-            t.serialize()
-        } else {
-            String::from("nil")
-        }
+        self.map_or_else(
+            || String::from("nil"),
+            crate::serialize::Serialize::serialize,
+        )
     }
 }
 


### PR DESCRIPTION
Fixes #104. No functional changes intended.

The following allows are required to pass Nursery lints without breaking pub API compatibility: 
clippy::module_name_repetitions
clippy::fallible_impl_from
clippy::needless_pass_by_value

I think all three could be fixed up before a major release. I think these are pretty good TODO markers that can be reevaluated as other issues are resolved (#105 and #106). 