### PR TITLE
Dependency bump. "cargo bench" works on rust 1.73.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ async = ["futures"]
 json = ["regex"]
 
 [dependencies]
-regex = {version = "1", optional = true }
-futures = {version = "0.3.5", optional = true }
+regex = { version = "1", optional = true }
+futures = { version = "0.3.5", optional = true }
 
 [dev-dependencies]
-tokio = {version = "0.2.22", features = ["macros"] }
-criterion = "0.3"
+tokio = { version = "1.33", features = ["full"] }
+criterion = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 edn-derive = "0.5.0"


### PR DESCRIPTION
Just a quick dependency bump before looking at adding a dependency.