### PR TITLE
Lints

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -55,5 +55,5 @@ jobs:
         - uses: dtolnay/rust-toolchain@stable
           with:
             components: clippy
-        - run: cargo clippy --all-features -- -W clippy::all -W clippy::pedantic -W clippy::nursery --deny warnings
-        - run: cargo clippy --no-default-features -- -W clippy::all -W clippy::pedantic -W clippy::nursery --deny warnings
+        - run: cargo clippy --all-features -- -W future-incompatible -W rust_2018_idioms -W clippy::all -W clippy::pedantic -W clippy::nursery --deny warnings
+        - run: cargo clippy --no-default-features -- -W future-incompatible -W rust_2018_idioms -W clippy::all -W clippy::pedantic -W clippy::nursery --deny warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,13 @@ keywords = ["EDN"]
 license = "MIT"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints.rust]
+rust_2018_idioms = "warn"
+future-incompatible = "warn"
+
+[lints.clippy]
+pedantic = "warn"
+nursery = "warn"
 
 [features]
 async = ["futures"]

--- a/benches/serialize.rs
+++ b/benches/serialize.rs
@@ -15,7 +15,7 @@ mod serde {
 
     pub fn criterion_benchmark(c: &mut Criterion) {
         c.bench_function("serde", |b| {
-            b.iter(|| serde_json::to_string(&val()).unwrap())
+            b.iter(|| serde_json::to_string(&val()).unwrap());
         });
     }
 

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -457,7 +457,7 @@ mod test {
         let nil = "nil";
         let unit: () = from_str(nil).unwrap();
 
-        assert_eq!(unit, ())
+        assert_eq!(unit, ());
     }
 
     #[test]
@@ -471,7 +471,7 @@ mod test {
                 "Cannot safely deserialize Set(Set({Str(\"a\"), Str(\"b\"), UInt(5)})) to BTreeSet"
                     .to_string()
             ))
-        )
+        );
     }
 
     #[test]
@@ -565,7 +565,7 @@ mod test {
             Edn::Vector(Vector::new(vec![Edn::Str(
                 "hello brave new world".to_string()
             )]))
-        )
+        );
     }
 
     #[test]
@@ -592,7 +592,7 @@ mod test {
         assert_eq!(
             edn,
             Edn::Uuid("af6d8699-f442-4dfd-8b26-37d80543186b".to_string())
-        )
+        );
     }
 
     #[test]
@@ -603,7 +603,7 @@ mod test {
         }
         impl Deserialize for Foo {
             fn deserialize(edn: &Edn) -> Result<Self, Error> {
-                Ok(Foo {
+                Ok(Self {
                     bar: from_edn(&edn[":bar"])?,
                 })
             }

--- a/src/edn/mod.rs
+++ b/src/edn/mod.rs
@@ -52,7 +52,7 @@ pub enum Edn {
 impl futures::future::Future for Edn {
     type Output = Self;
 
-    fn poll(self: Pin<&mut Self>, _cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         if self.to_string().is_empty() {
             Poll::Pending
         } else {
@@ -129,7 +129,7 @@ impl futures::future::Future for Vector {
     type Output = Self;
 
     #[allow(unused_comparisons, clippy::absurd_extreme_comparisons)]
-    fn poll(self: Pin<&mut Self>, _cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         if self.0.len() >= 0 {
             let pinned = self.to_owned();
             Poll::Ready(pinned)
@@ -164,7 +164,7 @@ impl futures::future::Future for List {
     type Output = Self;
 
     #[allow(unused_comparisons, clippy::absurd_extreme_comparisons)]
-    fn poll(self: Pin<&mut Self>, _cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         if self.0.len() >= 0 {
             let pinned = self.to_owned();
             Poll::Ready(pinned)
@@ -201,7 +201,7 @@ impl futures::future::Future for Set {
     type Output = Self;
 
     #[allow(unused_comparisons, clippy::absurd_extreme_comparisons)]
-    fn poll(self: Pin<&mut Self>, _cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         if self.0.len() >= 0 {
             let pinned = self.to_owned();
             Poll::Ready(pinned)
@@ -236,7 +236,7 @@ impl futures::future::Future for Map {
     type Output = Self;
 
     #[allow(unused_comparisons, clippy::absurd_extreme_comparisons)]
-    fn poll(self: Pin<&mut Self>, _cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         if self.0.len() >= 0 {
             let pinned = self.to_owned();
             Poll::Ready(pinned)

--- a/src/edn/utils/index.rs
+++ b/src/edn/utils/index.rs
@@ -143,7 +143,7 @@ mod private {
 struct Type<'a>(&'a Edn);
 
 impl<'a> fmt::Display for Type<'a> {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self.0 {
             Edn::Empty => formatter.write_str("empty"),
             Edn::Nil => formatter.write_str("null"),

--- a/src/edn/utils/mod.rs
+++ b/src/edn/utils/mod.rs
@@ -9,7 +9,7 @@ pub mod index;
 pub fn replace_keywords(json: String) -> String {
     let re = Regex::new(r#""\w*(\s\w*)*":"#).unwrap();
 
-    let edn = re.replace_all(&json[..], |caps: &Captures| {
+    let edn = re.replace_all(&json[..], |caps: &Captures<'_>| {
         let mut rcap = caps[0].replace(['\"', ':'], "").replace(['_', ' '], "-");
         rcap.insert(0, ':');
         rcap.to_string()
@@ -23,7 +23,7 @@ pub fn replace_keywords(json: String) -> String {
 pub fn replace_char(json: String) -> String {
     let c_re = Regex::new(r"'.'").unwrap();
 
-    let edn = c_re.replace_all(&json[..], |caps: &Captures| {
+    let edn = c_re.replace_all(&json[..], |caps: &Captures<'_>| {
         let mut rcap = caps[0].replace('\'', "");
         rcap.insert(0, '\\');
         rcap.to_string()

--- a/src/edn/utils/mod.rs
+++ b/src/edn/utils/mod.rs
@@ -21,7 +21,7 @@ pub fn replace_keywords(json: String) -> String {
 #[must_use]
 #[allow(clippy::needless_pass_by_value)]
 pub fn replace_char(json: String) -> String {
-    let c_re = Regex::new(r#"'.'"#).unwrap();
+    let c_re = Regex::new(r"'.'").unwrap();
 
     let edn = c_re.replace_all(&json[..], |caps: &Captures| {
         let mut rcap = caps[0].replace('\'', "");

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -122,7 +122,7 @@ mod test {
     #[test]
     fn nil_and_empty_edns() {
         assert_eq!(display_as_json(&Edn::Nil), String::from("null"));
-        assert_eq!(display_as_json(&Edn::Empty), String::from(""));
+        assert_eq!(display_as_json(&Edn::Empty), String::new());
     }
 
     #[test]
@@ -243,8 +243,8 @@ mod test {
             Edn::UInt(4),
         ]));
         let set = display_as_json(&edn);
-        assert!(set.contains("["));
-        assert!(set.contains("]"));
+        assert!(set.contains('['));
+        assert!(set.contains(']'));
         assert!(set.contains("-0.75"));
         assert!(set.contains("\"myBestie\""));
     }
@@ -260,7 +260,7 @@ mod test {
         assert_eq!(
             display_as_json(&map),
             "{\"1.2\": false, \"beloMonte\": 0.75, \"true\": \'d\'}"
-        )
+        );
     }
 
     #[test]
@@ -313,7 +313,7 @@ mod test {
         assert_eq!(
             display_as_json(&map),
             "{\"thisIsANamespace\": {\"1.2\": false, \"beloMonte\": 0.75, \"true\": \'d\'}}"
-        )
+        );
     }
 
     #[test]

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -345,7 +345,7 @@ mod test {
         assert_eq!(v_f32.serialize(), "[3.0, 12.1, 24.2, 72.3]");
         assert_eq!(v_i64.serialize(), "[3, 12, 24, 72]");
         assert_eq!(v_u64.serialize(), "[3, 12, 24, 72]");
-        assert_eq!(v_bool.serialize(), "[true, false]")
+        assert_eq!(v_bool.serialize(), "[true, false]");
     }
 
     #[test]
@@ -385,42 +385,42 @@ mod test {
 
         assert!(
             set_i8.contains("#{")
-                && set_i8.contains(",")
-                && set_i8.contains("3")
-                && set_i8.contains("}")
+                && set_i8.contains(',')
+                && set_i8.contains('3')
+                && set_i8.contains('}')
         );
         assert!(
             set_u16.contains("#{")
-                && set_u16.contains(",")
-                && set_u16.contains("3")
-                && set_u16.contains("}")
+                && set_u16.contains(',')
+                && set_u16.contains('3')
+                && set_u16.contains('}')
         );
         assert!(
             set_i64.contains("#{")
-                && set_i64.contains(",")
-                && set_i64.contains("3")
-                && set_i64.contains("}")
+                && set_i64.contains(',')
+                && set_i64.contains('3')
+                && set_i64.contains('}')
         );
         assert!(
             set_bool.contains("#{")
-                && set_bool.contains(",")
+                && set_bool.contains(',')
                 && set_bool.contains("true")
                 && set_bool.contains("false")
-                && set_bool.contains("}")
+                && set_bool.contains('}')
         );
         assert!(
             set_str.contains("#{")
-                && set_str.contains(",")
+                && set_str.contains(',')
                 && set_str.contains("\"aba\"")
                 && set_str.contains("\"cate\"")
-                && set_str.contains("}")
+                && set_str.contains('}')
         );
         assert!(
             set_string.contains("#{")
-                && set_string.contains(",")
+                && set_string.contains(',')
                 && set_string.contains("\"aba\"")
                 && set_string.contains("\"cate\"")
-                && set_string.contains("}")
+                && set_string.contains('}')
         );
     }
 
@@ -452,42 +452,42 @@ mod test {
 
         assert!(
             set_i8.contains("#{")
-                && set_i8.contains(",")
-                && set_i8.contains("3")
-                && set_i8.contains("}")
+                && set_i8.contains(',')
+                && set_i8.contains('3')
+                && set_i8.contains('}')
         );
         assert!(
             set_u16.contains("#{")
-                && set_u16.contains(",")
-                && set_u16.contains("3")
-                && set_u16.contains("}")
+                && set_u16.contains(',')
+                && set_u16.contains('3')
+                && set_u16.contains('}')
         );
         assert!(
             set_i64.contains("#{")
-                && set_i64.contains(",")
-                && set_i64.contains("3")
-                && set_i64.contains("}")
+                && set_i64.contains(',')
+                && set_i64.contains('3')
+                && set_i64.contains('}')
         );
         assert!(
             set_bool.contains("#{")
-                && set_bool.contains(",")
+                && set_bool.contains(',')
                 && set_bool.contains("true")
                 && set_bool.contains("false")
-                && set_bool.contains("}")
+                && set_bool.contains('}')
         );
         assert!(
             set_str.contains("#{")
-                && set_str.contains(",")
+                && set_str.contains(',')
                 && set_str.contains("\"aba\"")
                 && set_str.contains("\"cate\"")
-                && set_str.contains("}")
+                && set_str.contains('}')
         );
         assert!(
             set_string.contains("#{")
-                && set_string.contains(",")
+                && set_string.contains(',')
                 && set_string.contains("\"aba\"")
                 && set_string.contains("\"cate\"")
-                && set_string.contains("}")
+                && set_string.contains('}')
         );
     }
 
@@ -540,20 +540,20 @@ mod test {
         assert!(
             m_i64.contains(":hello-world 5")
                 && m_i64.contains(":bye-bye 125")
-                && m_i64.contains("{")
-                && m_i64.contains("}")
+                && m_i64.contains('{')
+                && m_i64.contains('}')
         );
         assert!(
             m_bool.contains(":hello-world true")
                 && m_bool.contains(":bye-bye false")
-                && m_bool.contains("{")
-                && m_bool.contains("}")
+                && m_bool.contains('{')
+                && m_bool.contains('}')
         );
         assert!(
             m_str.contains(":hello-world \"this is str 1\"")
                 && m_str.contains(":bye-bye \"this is str 2\"")
-                && m_str.contains("{")
-                && m_str.contains("}")
+                && m_str.contains('{')
+                && m_str.contains('}')
         );
     }
 

--- a/tests/emit.rs
+++ b/tests/emit.rs
@@ -1,8 +1,6 @@
-extern crate edn_rs;
-
 #[cfg(feature = "json")]
 mod tests {
-    use crate::edn_rs::json_to_edn;
+    use edn_rs::json_to_edn;
 
     #[test]
     fn emits_helloworld_edn() {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,5 @@
 #![recursion_limit = "512"]
 
-extern crate edn_derive;
-extern crate edn_rs;
 pub mod emit;
 pub mod parse;
 pub mod ser;


### PR DESCRIPTION
Added lints `future-incompatible` and `rust_2018_idioms` and appropriate changes.

https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html#lint-configuration-through-cargo
Now using cargo's lint configuration from 1.74. In the near future, the CI can also be changed to

```
- run: cargo clippy --all-features -- --deny warnings
- run: cargo clippy --no-default-features -- --deny warnings
```
