### PR TITLE
Bump to rust edition 2021 + best practices.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,8 @@ jobs:
           name: Run example tests with json feature
           command: cargo test --example json_to_edn --features "json"
       - run:
-          name: Run example tests with async feature
-          command: cargo run --example async --features "async"
+          name: Run example tests with async
+          command: cargo run --example async
 
   lint:
     docker:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,7 +33,7 @@ jobs:
       - name: example_edn_to_json
         run: cargo test --example edn_to_json --features "json"
       - name: example_async
-        run: cargo run --example async --features "async"
+        run: cargo run --example async
       - name: example_no_sets
         run: cargo run --example struct_from_str --no-default-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/edn-rs/"
 repository = "https://github.com/naomijub/edn-rs"
 keywords = ["EDN"]
 license = "MIT"
-edition = "2018"
+edition = "2021"
 
 [lints.rust]
 rust_2018_idioms = "warn"
@@ -19,14 +19,12 @@ pedantic = "warn"
 nursery = "warn"
 
 [features]
-async = ["futures"]
 default = ["sets"]
 json = ["regex"]
 sets = ["ordered-float"]
 
 [dependencies]
 regex = { version = "1", optional = true }
-futures = { version = "0.3.5", optional = true }
 ordered-float = { version = "4.1", default-features = false, optional = true }
 
 [dev-dependencies]
@@ -55,7 +53,6 @@ harness = false
 
 [[example]]
 name = "async"
-required-features = ["async"]
 
 [[example]]
 name = "json_to_edn"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ examples:
 	cargo test --examples --no-fail-fast
 	cargo test --example json_to_edn --features "json"
 	cargo test --example edn_to_json --features "json"
-	cargo run --example async --features "async"
+	cargo run --example async
 
 doc-tests:
 	cargo test --doc

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 
 Crate to parse and emit EDN 
 * **This lib does not make effort to conform the EDN received to EDN Spec.** The lib that generated this EDN should be responsible for this. For more information on Edn Spec please visit: https://github.com/edn-format/edn.
-* Minimal Rust Version is 1.46+.
-* Library is almost stable (1.0.0), just missing [issue-4](https://github.com/naomijub/edn-rs/issues/4) to reach feature stability and possible bugfix for [equality rules](https://github.com/naomijub/edn-rs/issues/95). **No breaking changes predicted**.
+* MSRV (minimal supported rust version) is stable minus 2 versions. Once stable (1.0.0), the plan is to indefinitely maintain the MSRV.
+* Library is almost stable (1.0.0), just missing [issue-4](https://github.com/naomijub/edn-rs/issues/4) to reach feature stability and possible bugfix for [equality rules](https://github.com/naomijub/edn-rs/issues/95). **No breaking changes with default features are predicted**.
 
 Our **MTTA** (Mean time to acknowledge) is around `one day`; 
 <!---->
@@ -354,39 +354,6 @@ fn complex_ok() -> Result<(), EdnError> {
 //    "{:list: [{:age 66, :cool true, :name \"rose\", }, {:age 33, :cool false, :name \"josh\", }, {:age 296, :cool true, :name \"eva\", }, ], }"
 
     Ok(())
-}
-```
-
-## Using `async/await` with Edn type
-
-Edn supports `futures` by using the feature `async`. To enable this feature add to your `Cargo.toml`  dependencies the following line `edn-rs = { version = 0.17.4", features = ["async"] }` and you can use futures as in the following example.
-
-```rust
-use edn_rs::{edn, Double, Edn, Vector};
-use futures::prelude::*;
-use futures::Future;
-use tokio::prelude::*;
-
-async fn foo() -> impl Future<Output = Edn> + Send {
-    edn!([1 1.5 "hello" :key])
-}
-
-#[tokio::main]
-async fn main() {
-    let edn = foo().await.await;
-
-    println!("{}", edn.to_string());
-    assert_eq!(edn, edn!([1 1.5 "hello" :key]));
-
-    assert_eq!(edn[1].to_float(), Some(1.5f64));
-}
-```
-
-The objective of `foo` is to show that `Edn` can be wrapped with a `Future`. If you want to return an `Edn` from an `async` function just use:
-
-```rust
-async fn foo() -> Edn {
-    edn!([1 1.5 "hello" :key])
 }
 ```
 

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,16 +1,19 @@
-use edn_rs::{edn, Edn, Vector};
-use futures::Future;
+use std::str::{self, FromStr};
 
-async fn foo() -> impl Future<Output = Edn> + Send {
-    edn!([1 1.5 "hello" :key])
-}
+use edn_rs::{edn, Edn, Vector};
+use tokio::fs::File;
+use tokio::io::AsyncReadExt;
 
 #[tokio::main]
-async fn main() {
-    let edn = foo().await.await;
+async fn main() -> std::io::Result<()> {
+    let mut file = File::open("examples/test_edn.txt").await?;
+    let mut contents = vec![];
+    file.read_to_end(&mut contents).await?;
 
-    assert_eq!("[1, 1.5, \"hello\", :key, ]", edn.to_string());
-    assert_eq!(edn, edn!([1 1.5 "hello" :key]));
+    let edn = Edn::from_str(str::from_utf8(&contents).unwrap());
+    println!("{edn:?}");
 
-    assert_eq!(edn[1].to_float(), Some(1.5f64));
+    let edn = edn!([1 1.5 "hello" :key]);
+    println!("{edn:?}");
+    Ok(())
 }

--- a/examples/test_edn.txt
+++ b/examples/test_edn.txt
@@ -1,0 +1,1 @@
+{ :hello "async" :map {:bye 2018 :num 0x42}}

--- a/src/edn/mod.rs
+++ b/src/edn/mod.rs
@@ -7,12 +7,6 @@ use std::collections::BTreeSet;
 use std::convert::TryFrom;
 use utils::index::Index;
 
-#[cfg(feature = "async")]
-use core::pin::Pin;
-#[cfg(feature = "async")]
-use futures::task;
-#[cfg(feature = "async")]
-use futures::task::Poll;
 #[cfg(feature = "sets")]
 use ordered_float::OrderedFloat;
 
@@ -46,20 +40,6 @@ pub enum Edn {
     NamespacedMap(String, Map),
     Nil,
     Empty,
-}
-
-#[cfg(feature = "async")]
-impl futures::future::Future for Edn {
-    type Output = Self;
-
-    fn poll(self: Pin<&mut Self>, _cx: &mut task::Context<'_>) -> Poll<Self::Output> {
-        if self.to_string().is_empty() {
-            Poll::Pending
-        } else {
-            let pinned = self.to_owned();
-            Poll::Ready(pinned)
-        }
-    }
 }
 
 #[derive(Clone, Ord, Debug, Eq, PartialEq, PartialOrd, Hash)]
@@ -124,21 +104,6 @@ impl Vector {
     }
 }
 
-#[cfg(feature = "async")]
-impl futures::future::Future for Vector {
-    type Output = Self;
-
-    #[allow(unused_comparisons, clippy::absurd_extreme_comparisons)]
-    fn poll(self: Pin<&mut Self>, _cx: &mut task::Context<'_>) -> Poll<Self::Output> {
-        if self.0.len() >= 0 {
-            let pinned = self.to_owned();
-            Poll::Ready(pinned)
-        } else {
-            Poll::Pending
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "sets", derive(Eq, PartialOrd, Ord))]
 pub struct List(Vec<Edn>);
@@ -156,21 +121,6 @@ impl List {
     #[must_use]
     pub fn to_vec(self) -> Vec<Edn> {
         self.0
-    }
-}
-
-#[cfg(feature = "async")]
-impl futures::future::Future for List {
-    type Output = Self;
-
-    #[allow(unused_comparisons, clippy::absurd_extreme_comparisons)]
-    fn poll(self: Pin<&mut Self>, _cx: &mut task::Context<'_>) -> Poll<Self::Output> {
-        if self.0.len() >= 0 {
-            let pinned = self.to_owned();
-            Poll::Ready(pinned)
-        } else {
-            Poll::Pending
-        }
     }
 }
 
@@ -196,21 +146,6 @@ impl Set {
     }
 }
 
-#[cfg(feature = "async")]
-impl futures::future::Future for Set {
-    type Output = Self;
-
-    #[allow(unused_comparisons, clippy::absurd_extreme_comparisons)]
-    fn poll(self: Pin<&mut Self>, _cx: &mut task::Context<'_>) -> Poll<Self::Output> {
-        if self.0.len() >= 0 {
-            let pinned = self.to_owned();
-            Poll::Ready(pinned)
-        } else {
-            Poll::Pending
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "sets", derive(Eq, PartialOrd, Ord))]
 pub struct Map(BTreeMap<String, Edn>);
@@ -228,21 +163,6 @@ impl Map {
     #[must_use]
     pub fn to_map(self) -> BTreeMap<String, Edn> {
         self.0
-    }
-}
-
-#[cfg(feature = "async")]
-impl futures::future::Future for Map {
-    type Output = Self;
-
-    #[allow(unused_comparisons, clippy::absurd_extreme_comparisons)]
-    fn poll(self: Pin<&mut Self>, _cx: &mut task::Context<'_>) -> Poll<Self::Output> {
-        if self.0.len() >= 0 {
-            let pinned = self.to_owned();
-            Poll::Ready(pinned)
-        } else {
-            Poll::Pending
-        }
     }
 }
 

--- a/src/edn/utils/index.rs
+++ b/src/edn/utils/index.rs
@@ -42,13 +42,10 @@ impl Index for u64 {
             Edn::Vector(ref mut vec) => {
                 let len = vec.0.len();
                 let idx = usize::try_from(*self).unwrap_or_else(|e| {
-                    panic!("index {} cannot fit in usize with error {}", self, e);
+                    panic!("index {self} cannot fit in usize with error {e}");
                 });
                 vec.0.get_mut(idx).unwrap_or_else(|| {
-                    panic!(
-                        "cannot access index {} of EDN array of length {}",
-                        self, len
-                    )
+                    panic!("cannot access index {self} of EDN array of length {len}")
                 })
             }
             Edn::NamespacedMap(_, ref mut map) => map.0.entry(self.to_string()).or_insert(Edn::Nil),


### PR DESCRIPTION
The `async` feature has been removed.
The async example is now using stable async/futures.

Relevant discussions:
https://github.com/naomijub/edn-rs/pull/116
https://github.com/naomijub/edn-rs/issues/117

I'm not sure how many people use this crate, but I think this might be one of the last big breaking changes for standard features. A `0.18.0` release might be a good idea. An added note about an org change (https://github.com/naomijub/edn-rs/issues/109) from `0.19.0` might be a good idea.