### PR TITLE
Remove `Inst` and `Uuid`

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,8 +374,7 @@ fn complex_ok() -> Result<(), EdnError> {
     - [x] List `"(1 :2 \"d\")"`
     - [x] Set `"#{1 2 3}"`
     - [x] Map `"{:a 1 :b 2 }"`
-    - [x] Inst `#inst \"yyyy-mm-ddTHH:MM:ss\"`
-    - [x] UUID `#uuid \"<some-uuid>\"`
+    - [x] Tag `#inst \"yyyy-mm-ddTHH:MM:ss\"`, `#uuid \"<some-uuid>\"` as string data (no custom reader support)
     - [x] Nested structures `"{:a \"2\" :b [true false] :c #{:A {:a :b} nil}}"`
 - [ ] Simple data structures in one another [`edn!`](https://docs.rs/edn-rs/0.17.4/edn_rs/macro.edn.html):
     - [x] Vec in Vec `"[1 2 [:3 \"4\"]]"`

--- a/src/deserialize/parse.rs
+++ b/src/deserialize/parse.rs
@@ -161,26 +161,6 @@ fn read_tagged(chars: &mut std::iter::Enumerate<std::str::Chars<'_>>) -> Result<
         .map(|c| c.1)
         .collect::<String>();
 
-    if tag.starts_with("inst") {
-        return Ok(Edn::Inst(
-            chars
-                .skip_while(|c| c.1 == '\"' || c.1.is_whitespace())
-                .take_while(|c| c.1 != '\"')
-                .map(|c| c.1)
-                .collect::<String>(),
-        ));
-    }
-
-    if tag.starts_with("uuid") {
-        return Ok(Edn::Uuid(
-            chars
-                .skip_while(|c| c.1 == '\"' || c.1.is_whitespace())
-                .take_while(|c| c.1 != '\"')
-                .map(|c| c.1)
-                .collect::<String>(),
-        ));
-    }
-
     Ok(Edn::Tagged(
         tag,
         Box::new(parse_consuming(chars.next(), chars)?),

--- a/src/edn/mod.rs
+++ b/src/edn/mod.rs
@@ -35,8 +35,6 @@ pub enum Edn {
     Rational(String),
     Char(char),
     Bool(bool),
-    Inst(String),
-    Uuid(String),
     Nil,
     Empty,
 }
@@ -250,8 +248,6 @@ impl core::fmt::Display for Edn {
             Self::Rational(r) => r.to_string(),
             Self::Bool(b) => format!("{b}"),
             Self::Char(c) => format!("{c}"),
-            Self::Inst(t) => format!("#inst \"{t}\""),
-            Self::Uuid(t) => format!("#uuid \"{t}\""),
             Self::Nil => String::from("nil"),
             Self::Empty => String::new(),
             Self::Tagged(tag, edn) => format!("#{tag} {edn}"),
@@ -639,28 +635,6 @@ impl Edn {
         }
     }
 
-    /// `to_str_uuid` returns am `Option<String>` with `Some` containing the string representing the UUID for type `Edn::Uuid`
-    /// Other types return `None`
-    #[must_use]
-    pub fn to_str_uuid(&self) -> Option<String> {
-        if let Self::Uuid(uuid) = self {
-            Some(uuid.clone())
-        } else {
-            None
-        }
-    }
-
-    /// `to_str_INST` returns am `Option<String>` with `Some` containing the string representing the instant for type `Edn::Inst`
-    /// Other types return `None`
-    #[must_use]
-    pub fn to_str_inst(&self) -> Option<String> {
-        if let Self::Inst(inst) = self {
-            Some(inst.clone())
-        } else {
-            None
-        }
-    }
-
     /// Method `to_json` allows you to convert a `edn_rs::Edn` into a JSON string. Type convertions are:
     /// `Edn::Vector(v)` => a vector like `[value1, value2, ..., valueN]`
     /// `Edn::Set(s)` => a vector like `[value1, value2, ..., valueN]`
@@ -942,50 +916,6 @@ mod test {
         let edn_vec = edn.to_vec().unwrap();
 
         assert_eq!(edn_vec, expected);
-    }
-
-    #[test]
-    fn inst_to_string() {
-        let inst = Edn::Inst("2020-09-18T01:16:25.909-00:00".to_string());
-
-        assert_eq!(inst.to_string(), "#inst \"2020-09-18T01:16:25.909-00:00\"");
-        let str_inst: String = crate::deserialize::from_edn(&inst).unwrap();
-        assert_eq!(str_inst, "#inst \"2020-09-18T01:16:25.909-00:00\"");
-    }
-
-    #[test]
-    fn inst_to_str_inst() {
-        let inst = Edn::Inst("2020-09-18T01:16:25.909-00:00".to_string());
-
-        assert_eq!(inst.to_str_inst().unwrap(), "2020-09-18T01:16:25.909-00:00");
-
-        let uuid = Edn::Uuid("af6d8699-f442-4dfd-8b26-37d80543186b".to_string());
-        assert_eq!(uuid.to_str_inst(), None);
-    }
-
-    #[test]
-    fn uuid_to_string() {
-        let uuid = Edn::Uuid("af6d8699-f442-4dfd-8b26-37d80543186b".to_string());
-
-        assert_eq!(
-            uuid.to_string(),
-            "#uuid \"af6d8699-f442-4dfd-8b26-37d80543186b\""
-        );
-        let str_uuid: String = crate::deserialize::from_edn(&uuid).unwrap();
-        assert_eq!(str_uuid, "#uuid \"af6d8699-f442-4dfd-8b26-37d80543186b\"");
-    }
-
-    #[test]
-    fn uuid_to_str_uuid() {
-        let uuid = Edn::Uuid("af6d8699-f442-4dfd-8b26-37d80543186b".to_string());
-
-        assert_eq!(
-            uuid.to_str_uuid().unwrap(),
-            "af6d8699-f442-4dfd-8b26-37d80543186b"
-        );
-
-        let inst = Edn::Inst("2020-09-18T01:16:25.909-00:00".to_string());
-        assert_eq!(inst.to_str_uuid(), None);
     }
 
     #[test]

--- a/src/edn/utils/index.rs
+++ b/src/edn/utils/index.rs
@@ -148,8 +148,6 @@ impl<'a> fmt::Display for Type<'a> {
             Edn::Char(_) => formatter.write_str("char"),
             Edn::Symbol(_) => formatter.write_str("symbol"),
             Edn::Double(_) => formatter.write_str("double"),
-            Edn::Inst(_) => formatter.write_str("inst"),
-            Edn::Uuid(_) => formatter.write_str("uuid"),
             Edn::Rational(_) => formatter.write_str("rational"),
             Edn::Tagged(_, _) => formatter.write_str("tagged-element"),
         }

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -23,8 +23,6 @@ pub fn display_as_json(edn: &Edn) -> String {
         Edn::Rational(r) => format!("{}", rational_to_double(r).unwrap()),
         Edn::Char(c) => format!("'{c}'"),
         Edn::Bool(b) => format!("{b}"),
-        Edn::Inst(inst) => format!("{inst:?}"),
-        Edn::Uuid(uuid) => format!("{uuid:?}"),
         Edn::Nil => String::from("null"),
         Edn::Empty => String::new(),
         Edn::Tagged(tag, content) => format!("{{ \"{}\": {}}}", tag, display_as_json(content)),
@@ -151,21 +149,6 @@ mod test {
     fn chars() {
         assert_eq!(display_as_json(&Edn::Char('e')), String::from("'e'"));
         assert_eq!(display_as_json(&Edn::Char('5')), String::from("'5'"));
-    }
-
-    #[test]
-    fn inst_and_uuid() {
-        let inst = Edn::Inst("2020-09-18T01:16:25.909-00:00".to_string());
-        let uuid = Edn::Uuid("af6d8699-f442-4dfd-8b26-37d80543186b".to_string());
-
-        assert_eq!(
-            display_as_json(&inst),
-            "\"2020-09-18T01:16:25.909-00:00\"".to_string()
-        );
-        assert_eq!(
-            display_as_json(&uuid),
-            "\"af6d8699-f442-4dfd-8b26-37d80543186b\"".to_string()
-        );
     }
 
     #[test]

--- a/tests/deserialize.rs
+++ b/tests/deserialize.rs
@@ -387,7 +387,9 @@ mod test {
         assert_eq!(
             Edn::from_str("{:date  #inst \"2020-07-16T21:53:14.628-00:00\"}").unwrap(),
             Edn::Map(Map::new(map! {
-                ":date".to_string() => Edn::Inst("2020-07-16T21:53:14.628-00:00".to_string())
+                ":date".to_string() =>
+                    Edn::Tagged("inst".to_string(),
+                                Box::new(Edn::Str("2020-07-16T21:53:14.628-00:00".to_string())))
             }))
         );
     }
@@ -395,11 +397,14 @@ mod test {
     #[test]
     fn uuid() {
         let uuid = "#uuid \"af6d8699-f442-4dfd-8b26-37d80543186b\"";
-        let edn: Edn = Edn::from_str(uuid).unwrap();
+        let edn = Edn::from_str(uuid).unwrap();
 
         assert_eq!(
             edn,
-            Edn::Uuid("af6d8699-f442-4dfd-8b26-37d80543186b".to_string())
+            Edn::Tagged(
+                "uuid".to_string(),
+                Box::new(Edn::Str("af6d8699-f442-4dfd-8b26-37d80543186b".to_string()))
+            )
         );
     }
 

--- a/tests/deserialize_sets.rs
+++ b/tests/deserialize_sets.rs
@@ -136,7 +136,7 @@ mod test {
                 Edn::Key(":b".to_string()),
                 Edn::Map(Map::new(map! {
                     ":c".to_string() => Edn::Key(":d".to_string()),
-                    ":date".to_string() => Edn::Inst("2020-07-16T21:53:14.628-00:00".to_string()),
+                    ":date".to_string() => Edn::Tagged("inst".to_string(), Box::new(Edn::Str("2020-07-16T21:53:14.628-00:00".to_string()))),
                     "::c".to_string() => Edn::Key("::d".to_string())
                 })),
                 Edn::Nil


### PR DESCRIPTION
copy/paste from the bloated/out of scope discussion on #120. Because of the test refactoring in #121, please only look at the last commit here.

> Also, ok on the tagged portion.

On second thought, I think we keep the tagged type so no data is lost, but remove `Uuid` and and `Inst`. Users can match against the tagged type and do what they need to do. Right now it's not correct and I don't think we want to add the dependencies to make it correct.

```
(clojure.edn/read-string "#uuid \"af6d8699---f442-4dfd-8b26-37d80543186b\"")
java.lang.IllegalArgumentException: UUID string too large [at <repl>:1:1]

(clojure.edn/read-string "#inst \"2020lolfoobar-07-16T21:53:14.628-00:00\"")
java.lang.RuntimeException: Unrecognized date/time syntax: 2020lolfoobar-07-16T21:53:14.628-00:00 [at <repl>:4:1]
```

We just parse the string, without failure. We can add it back in when/if something like uuid and chrono get into rust std or as an optional feature if there's demand.