### PR TITLE
Fix serialize/deserialize implementation for edn-derive

### DIFF
--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -117,7 +117,7 @@ macro_rules! impl_deserialize_int {
     };
 }
 
-impl_deserialize_int!(i8, i16, i32, i64);
+impl_deserialize_int!(i8, i16, i32, i64, isize);
 
 macro_rules! impl_deserialize_uint {
     ( $( $name:ty ),+ ) => {
@@ -134,7 +134,7 @@ macro_rules! impl_deserialize_uint {
     };
 }
 
-impl_deserialize_uint!(u8, u16, u32, u64);
+impl_deserialize_uint!(u8, u16, u32, u64, usize);
 
 impl Deserialize for bool {
     fn deserialize(edn: &Edn) -> Result<Self, Error> {

--- a/src/edn/utils/index.rs
+++ b/src/edn/utils/index.rs
@@ -20,6 +20,7 @@ impl Index for u64 {
             return match *v {
                 Edn::Vector(ref vec) => vec.0.get(idx),
                 Edn::List(ref vec) => vec.0.get(idx),
+                Edn::Map(ref map) => map.0.get(&self.to_string()),
                 _ => None,
             };
         }
@@ -30,6 +31,7 @@ impl Index for u64 {
             return match *v {
                 Edn::Vector(ref mut vec) => vec.0.get_mut(idx),
                 Edn::List(ref mut vec) => vec.0.get_mut(idx),
+                Edn::Map(ref mut map) => map.0.get_mut(&self.to_string()),
                 _ => None,
             };
         }

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -184,7 +184,7 @@ where
 }
 
 // Primitive Types
-ser_primitives![i8, i16, i32, i64, u8, u16, u32, u64, f32, f64, bool];
+ser_primitives![i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, f32, f64, bool];
 
 impl Serialize for () {
     fn serialize(self) -> String {
@@ -311,11 +311,13 @@ mod test {
         assert_eq!(8i32.serialize(), String::from("8"));
         assert_eq!(8i64.serialize(), String::from("8"));
         assert_eq!(8i64.serialize(), String::from("8"));
+        assert_eq!(8isize.serialize(), String::from("8"));
         assert_eq!(128u8.serialize(), String::from("128"));
         assert_eq!(128u16.serialize(), String::from("128"));
         assert_eq!(128u32.serialize(), String::from("128"));
         assert_eq!(128u64.serialize(), String::from("128"));
         assert_eq!(128u64.serialize(), String::from("128"));
+        assert_eq!(128usize.serialize(), String::from("128"));
         assert_eq!(true.serialize(), String::from("true"));
     }
 

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -150,6 +150,6 @@ mod tests {
         assert_eq!(edn[3]["false"], edn!(:f));
         assert_eq!(edn[3]["false"], Edn::Key(":f".to_string()));
         assert_eq!(edn[3]["2"], Edn::Str("banana".to_string()));
-        assert_eq!(edn[3][2], Edn::Nil);
+        assert_eq!(edn[3][2], Edn::Str("banana".to_string()));
     }
 }

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -143,11 +143,13 @@ mod tests {
 
     #[test]
     fn navigate_data_structure() {
-        let edn = edn!([1 1.2 3 {false :f nil 3/4}]);
+        let edn = edn!([1 1.2 3 {false :f nil 3/4 2 "banana"}]);
 
         assert_eq!(edn[1], edn!(1.2));
         assert_eq!(edn[1], Edn::Double(1.2f64.into()));
         assert_eq!(edn[3]["false"], edn!(:f));
         assert_eq!(edn[3]["false"], Edn::Key(":f".to_string()));
+        assert_eq!(edn[3]["2"], Edn::Str("banana".to_string()));
+        assert_eq!(edn[3][2], Edn::Nil);
     }
 }


### PR DESCRIPTION
This PR fixes `edn-derive` (currently failing the tests).

The commit messages explain the fix :slightly_smiling_face: 

Related to https://github.com/edn-rs/edn-derive/issues/32

<!--

data for nerds:

https://github.com/edn-rs/edn-rs/blob/74f2bdcad625167cb71115dbf772f167b0c39905/src/edn/utils/index.rs#L20
https://github.com/edn-rs/edn-rs/commit/1964e9f4e100243677e42cf5db9544f29273b798#diff-a935746693316e92ab0863b119c775d65be719f99a750774470d7fd7d97d8cf4L20

-->