### PR TITLE
The crate is now no_std with no breaking changes with default-features. 

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,7 +25,7 @@ jobs:
       - name: test_lib_features
         run: cargo test --all-features --no-fail-fast
       - name: test_lib_no_default_features
-        run: cargo test --no-default-features --no-fail-fast
+        run: cargo test --features std --no-default-features --no-fail-fast
       - name: example_fast
         run: cargo test --examples --no-fail-fast
       - name: example_json_to_edn
@@ -35,7 +35,7 @@ jobs:
       - name: example_async
         run: cargo run --example async
       - name: example_no_sets
-        run: cargo run --example struct_from_str --no-default-features
+        run: cargo run --example struct_from_str --features std --no-default-features
 
   fmt:
       runs-on: ubuntu-latest
@@ -56,4 +56,5 @@ jobs:
           with:
             components: clippy
         - run: cargo clippy --all-features -- -W future-incompatible -W rust_2018_idioms -W clippy::all -W clippy::pedantic -W clippy::nursery --deny warnings
+        - run: cargo clippy --features std --no-default-features -- -W future-incompatible -W rust_2018_idioms -W clippy::all -W clippy::pedantic -W clippy::nursery --deny warnings
         - run: cargo clippy --no-default-features -- -W future-incompatible -W rust_2018_idioms -W clippy::all -W clippy::pedantic -W clippy::nursery --deny warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
+workspace = { members = ["no_std_rp2040"] }
 [package]
 name = "edn-rs"
 version = "0.17.4"
-authors = ["Julia Naomi <jnboeira@outlook.com>",  "Eva Pace <eba.pachi@gmail.com>"]
+authors = ["Julia Naomi <jnboeira@outlook.com>",  "Eva Pace <eba.pachi@gmail.com>", "Kevin Nakamura <grinkers@grinkers.net>"]
 description = "Crate to parse and emit EDN"
 readme = "README.md"
 documentation = "https://docs.rs/edn-rs/"
 repository = "https://github.com/edn-rs/edn-rs"
-keywords = ["EDN"]
+keywords = ["EDN", "no_std"]
 license = "MIT"
 edition = "2021"
 
@@ -20,9 +21,10 @@ pedantic = "warn"
 nursery = "warn"
 
 [features]
-default = ["sets"]
+default = ["sets", "std"]
 json = ["regex"]
 sets = ["ordered-float"]
+std = []
 
 [dependencies]
 regex = { version = "1", optional = true }

--- a/bb.edn
+++ b/bb.edn
@@ -2,24 +2,26 @@
  {clean                        {:doc      "Removes target folder"
                                 :requires ([babashka.fs :as fs])
                                 :task     (fs/delete-tree "target")}
-
   test_lib_features            (shell "cargo test --all-features --no-fail-fast")
-  test_lib_no_default_features (shell "cargo test --no-default-features --no-fail-fast")
+  test_lib_no_default_features (shell "cargo test --features std --no-default-features --no-fail-fast")
   example_fast                 (shell "cargo test --examples --no-fail-fast")
   example_json_to_edn          (shell "cargo test --example json_to_edn --features \"json\"")
   example_edn_to_json          (shell "cargo test --example edn_to_json --features \"json\"")
   example_async                (shell "cargo run --example async")
-  example_no_sets              (shell "cargo run --example struct_from_str --no-default-features")
-
+  example_no_sets              (shell "cargo run --example struct_from_str --features std --no-default-features")
   cargo-test                   {:doc     "Runs all cargo tests"
                                 :depends [test_lib_features test_lib_no_default_features example_fast
                                           example_json_to_edn example_edn_to_json example_edn_to_json
                                           example_async example_no_sets]}
   cargo-fmt                    {:doc  "Checks cargo fmt"
                                 :task (shell "cargo fmt --check")}
-  cargo-clippy                 {:doc  "Runs cargo clippy"
-                                :task (do
-                                        (shell "cargo clippy --all-features -- -W future-incompatible -W rust_2018_idioms -W clippy::all -W clippy::pedantic -W clippy::nursery --deny warnings")
-                                        (shell "cargo clippy --no-default-features -- -W future-incompatible -W rust_2018_idioms -W clippy::all -W clippy::pedantic -W clippy::nursery --deny warnings"))}
+  cargo-clippy-all-features    {:doc  "Cargo clippy with all features"
+                                :task (shell "cargo clippy --all-features -- -W future-incompatible -W rust_2018_idioms -W clippy::all -W clippy::pedantic -W clippy::nursery --deny warnings")}
+  cargo-clippy-no-sets-std     {:doc  "Cargo clippy with all features"
+                                :task (shell "cargo clippy --features std --no-default-features -- -W future-incompatible -W rust_2018_idioms -W clippy::all -W clippy::pedantic -W clippy::nursery --deny warnings")}
+  cargo-clippy-no-std          {:doc  "Cargo clippy with all features"
+                                :task (shell "cargo clippy --no-default-features -- -W future-incompatible -W rust_2018_idioms -W clippy::all -W clippy::pedantic -W clippy::nursery --deny warnings")}
+  clippy                       {:doc     "Runs cargo clippy"
+                                :depends [cargo-clippy-all-features cargo-clippy-no-sets-std cargo-clippy-no-std]}
   test                         {:doc     "Runs all tests and checks"
                                 :depends [cargo-test cargo-fmt cargo-clippy]}}}

--- a/bb.edn
+++ b/bb.edn
@@ -24,4 +24,4 @@
   clippy                       {:doc     "Runs cargo clippy"
                                 :depends [cargo-clippy-all-features cargo-clippy-no-sets-std cargo-clippy-no-std]}
   test                         {:doc     "Runs all tests and checks"
-                                :depends [cargo-test cargo-fmt cargo-clippy]}}}
+                                :depends [cargo-test cargo-fmt clippy]}}}

--- a/no_std_rp2040/Cargo.toml
+++ b/no_std_rp2040/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "no_std_rp2040"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+edn-rs = { path = "..", default-features = false }
+embedded-alloc = "0.5.1"
+
+[lib]
+name = "rustlib"
+crate-type = ["staticlib"]
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"

--- a/no_std_rp2040/src/lib.rs
+++ b/no_std_rp2040/src/lib.rs
@@ -1,0 +1,36 @@
+#![no_main]
+#![allow(unsafe_code)]
+#![no_std]
+
+use core::panic::PanicInfo;
+
+#[panic_handler]
+fn panic(_panic: &PanicInfo<'_>) -> ! {
+    loop {}
+}
+
+use core::str::FromStr;
+
+use edn_rs::{Edn, EdnError};
+use embedded_alloc::Heap;
+
+#[global_allocator]
+static HEAP: Heap = Heap::empty();
+
+fn init_allocator() {
+    use core::mem::MaybeUninit;
+    const HEAP_SIZE: usize = 1024;
+    static mut HEAP_MEM: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
+    unsafe { HEAP.init(HEAP_MEM.as_ptr() as usize, HEAP_SIZE) }
+}
+
+fn edn_from_str() -> Result<Edn, EdnError> {
+    let edn_str = "{:a \"2\"   :b [true false] :c #{:A nil {:a :b}}}";
+    Edn::from_str(edn_str)
+}
+
+fn main() {
+    init_allocator();
+
+    let _edn = edn_from_str();
+}

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -1,9 +1,18 @@
-use crate::edn::{Edn, Error};
-use std::collections::{BTreeMap, HashMap};
+use alloc::collections::BTreeMap;
 #[cfg(feature = "sets")]
-use std::collections::{BTreeSet, HashSet};
-use std::convert::TryFrom;
-use std::str::FromStr;
+use alloc::collections::BTreeSet;
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::any;
+use core::convert::{Into, TryFrom};
+use core::str::FromStr;
+#[cfg(feature = "std")]
+use std::collections::HashMap;
+#[cfg(all(feature = "sets", feature = "std"))]
+use std::collections::HashSet;
+
+use crate::edn::{Edn, Error};
 
 pub mod parse;
 
@@ -81,7 +90,7 @@ impl Deserialize for OrderedFloat<f64> {
     fn deserialize(edn: &Edn) -> Result<Self, Error> {
         edn.to_float()
             .ok_or_else(|| build_deserialize_error(edn, "edn_rs::Double"))
-            .map(std::convert::Into::into)
+            .map(Into::into)
     }
 }
 
@@ -89,7 +98,7 @@ impl Deserialize for f64 {
     fn deserialize(edn: &Edn) -> Result<Self, Error> {
         edn.to_float()
             .ok_or_else(|| build_deserialize_error(edn, "edn_rs::Double"))
-            .map(std::convert::Into::into)
+            .map(Into::into)
     }
 }
 
@@ -178,11 +187,12 @@ where
                 .ok_or_else(|| Error::Iter(format!("Could not create iter from {edn:?}")))?
                 .map(|e| Deserialize::deserialize(e))
                 .collect::<Result<Self, Error>>()?),
-            _ => Err(build_deserialize_error(edn, std::any::type_name::<Self>())),
+            _ => Err(build_deserialize_error(edn, any::type_name::<Self>())),
         }
     }
 }
 
+#[cfg(feature = "std")]
 impl<T, H> Deserialize for HashMap<String, T, H>
 where
     T: Deserialize,
@@ -205,7 +215,7 @@ where
                     ))
                 })
                 .collect::<Result<Self, Error>>(),
-            _ => Err(build_deserialize_error(edn, std::any::type_name::<Self>())),
+            _ => Err(build_deserialize_error(edn, any::type_name::<Self>())),
         }
     }
 }
@@ -231,7 +241,7 @@ where
                     ))
                 })
                 .collect::<Result<Self, Error>>(),
-            _ => Err(build_deserialize_error(edn, std::any::type_name::<Self>())),
+            _ => Err(build_deserialize_error(edn, any::type_name::<Self>())),
         }
     }
 }
@@ -256,7 +266,7 @@ where
                     })
                 })
                 .collect::<Result<Self, Error>>(),
-            _ => Err(build_deserialize_error(edn, std::any::type_name::<Self>())),
+            _ => Err(build_deserialize_error(edn, any::type_name::<Self>())),
         }
     }
 }
@@ -280,7 +290,7 @@ where
                     })
                 })
                 .collect::<Result<Self, Error>>(),
-            _ => Err(build_deserialize_error(edn, std::any::type_name::<Self>())),
+            _ => Err(build_deserialize_error(edn, any::type_name::<Self>())),
         }
     }
 }

--- a/src/edn/utils/index.rs
+++ b/src/edn/utils/index.rs
@@ -1,6 +1,9 @@
+use alloc::borrow::ToOwned;
+use alloc::string::{String, ToString};
+use core::convert::TryFrom;
+use core::{fmt, ops};
+
 use crate::edn::{Edn, Map};
-use std::convert::TryFrom;
-use std::{fmt, ops};
 
 /// This is a Copy of [`Serde_json::index`](https://docs.serde.rs/src/serde_json/value/index.rs.html)
 pub trait Index: private::Sealed {
@@ -63,7 +66,7 @@ impl Index for str {
     }
     fn index_or_insert<'v>(&self, v: &'v mut Edn) -> &'v mut Edn {
         if *v == Edn::Nil {
-            *v = Edn::Map(Map::new(std::collections::BTreeMap::new()));
+            *v = Edn::Map(Map::new(alloc::collections::BTreeMap::new()));
         }
         match *v {
             Edn::Map(ref mut map) => map.0.entry(self.to_owned()).or_insert(Edn::Nil),
@@ -120,6 +123,8 @@ where
 
 // Prevent users from implementing the Index trait.
 mod private {
+    use alloc::string::String;
+
     use crate::Edn;
 
     pub trait Sealed {}

--- a/src/edn/utils/mod.rs
+++ b/src/edn/utils/mod.rs
@@ -1,3 +1,6 @@
+use alloc::format;
+use alloc::string::{String, ToString};
+
 pub mod index;
 
 pub trait Attribute {

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -1,9 +1,17 @@
+use alloc::collections::BTreeMap;
+#[cfg(feature = "sets")]
+use alloc::collections::BTreeSet;
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
 use crate::edn::{rational_to_double, Edn};
 
 #[allow(clippy::module_name_repetitions)]
 pub fn display_as_json(edn: &Edn) -> String {
     match edn {
         Edn::Vector(v) => vec_to_json(&v.clone().to_vec()),
+        #[cfg(feature = "sets")]
         Edn::Set(s) => set_to_json_vec(&s.clone().to_set()),
         Edn::Map(map) => map_to_json(&map.clone().to_map()),
         Edn::List(l) => vec_to_json(&l.clone().to_vec()),
@@ -68,7 +76,8 @@ fn vec_to_json(vec: &[Edn]) -> String {
     s
 }
 
-fn set_to_json_vec(set: &std::collections::BTreeSet<Edn>) -> String {
+#[cfg(feature = "sets")]
+fn set_to_json_vec(set: &BTreeSet<Edn>) -> String {
     let set_str = set
         .iter()
         .map(display_as_json)
@@ -80,7 +89,7 @@ fn set_to_json_vec(set: &std::collections::BTreeSet<Edn>) -> String {
     s
 }
 
-fn map_to_json(map: &std::collections::BTreeMap<String, Edn>) -> String {
+fn map_to_json(map: &BTreeMap<String, Edn>) -> String {
     let map_str = map
         .iter()
         .map(|(k, e)| {
@@ -103,6 +112,9 @@ fn map_to_json(map: &std::collections::BTreeMap<String, Edn>) -> String {
 
 #[cfg(test)]
 mod test {
+    use alloc::boxed::Box;
+    use alloc::vec;
+
     use super::*;
     use crate::edn::{Edn, List, Map, Set, Vector};
     use crate::{map, set};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,14 @@
+#![no_std]
 #![recursion_limit = "512"]
+
 #[macro_use]
 mod macros;
+
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+use alloc::string::String;
 
 /// Edn type implementation
 pub mod edn;
@@ -38,7 +46,9 @@ pub mod serialize;
 pub(crate) mod json;
 
 #[cfg(feature = "json")]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
+#[cfg(feature = "json")]
+use alloc::string::ToString;
 
 mod deserialize;
 /// `json_to_edn` receives a json string and parses its common key-values to a regular EDN format. It requires feature `json`

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -1,3 +1,8 @@
+use alloc::collections::{BTreeMap, BTreeSet, LinkedList};
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
 /// Trait that allows you to implement Serialization for each type of your choice.
 /// Example:
 /// ```rust
@@ -48,6 +53,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T, H: std::hash::BuildHasher> Serialize for std::collections::HashSet<T, H>
 where
     T: Serialize,
@@ -66,7 +72,7 @@ where
     }
 }
 
-impl<T> Serialize for std::collections::BTreeSet<T>
+impl<T> Serialize for BTreeSet<T>
 where
     T: Serialize,
 {
@@ -84,7 +90,7 @@ where
     }
 }
 
-impl<T> Serialize for std::collections::LinkedList<T>
+impl<T> Serialize for LinkedList<T>
 where
     T: Serialize,
 {
@@ -101,6 +107,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T, H: std::hash::BuildHasher> Serialize for std::collections::HashMap<String, T, H>
 where
     T: Serialize,
@@ -118,6 +125,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T, H: ::std::hash::BuildHasher> Serialize for std::collections::HashMap<&str, T, H>
 where
     T: Serialize,
@@ -135,7 +143,7 @@ where
     }
 }
 
-impl<T> Serialize for std::collections::BTreeMap<String, T>
+impl<T> Serialize for BTreeMap<String, T>
 where
     T: Serialize,
 {
@@ -152,7 +160,7 @@ where
     }
 }
 
-impl<T> Serialize for std::collections::BTreeMap<&str, T>
+impl<T> Serialize for BTreeMap<&str, T>
 where
     T: Serialize,
 {
@@ -283,6 +291,9 @@ impl<A: Serialize, B: Serialize, C: Serialize, D: Serialize, E: Serialize, F: Se
 
 #[cfg(test)]
 mod test {
+    use alloc::collections::BTreeSet;
+    use alloc::vec;
+
     use super::*;
 
     #[test]
@@ -347,74 +358,7 @@ mod test {
 
     #[test]
     fn hashsets() {
-        use std::collections::HashSet;
-
-        let set_i8 = (vec![3i8, 12i8, 24i8, 72i8]
-            .into_iter()
-            .collect::<HashSet<i8>>())
-        .serialize();
-        let set_u16 = (vec![3u16, 12u16, 24u16, 72u16]
-            .into_iter()
-            .collect::<HashSet<u16>>())
-        .serialize();
-        let set_i64 = (vec![3i64, 12i64, 24i64, 72i64]
-            .into_iter()
-            .collect::<HashSet<i64>>())
-        .serialize();
-        let set_bool = (vec![true, false].into_iter().collect::<HashSet<bool>>()).serialize();
-        let set_str = (vec!["aba", "cate", "azul"]
-            .into_iter()
-            .collect::<HashSet<&str>>())
-        .serialize();
-        let set_string = (vec!["aba".to_string(), "cate".to_string(), "azul".to_string()]
-            .into_iter()
-            .collect::<HashSet<String>>())
-        .serialize();
-
-        assert!(
-            set_i8.contains("#{")
-                && set_i8.contains(',')
-                && set_i8.contains('3')
-                && set_i8.contains('}')
-        );
-        assert!(
-            set_u16.contains("#{")
-                && set_u16.contains(',')
-                && set_u16.contains('3')
-                && set_u16.contains('}')
-        );
-        assert!(
-            set_i64.contains("#{")
-                && set_i64.contains(',')
-                && set_i64.contains('3')
-                && set_i64.contains('}')
-        );
-        assert!(
-            set_bool.contains("#{")
-                && set_bool.contains(',')
-                && set_bool.contains("true")
-                && set_bool.contains("false")
-                && set_bool.contains('}')
-        );
-        assert!(
-            set_str.contains("#{")
-                && set_str.contains(',')
-                && set_str.contains("\"aba\"")
-                && set_str.contains("\"cate\"")
-                && set_str.contains('}')
-        );
-        assert!(
-            set_string.contains("#{")
-                && set_string.contains(',')
-                && set_string.contains("\"aba\"")
-                && set_string.contains("\"cate\"")
-                && set_string.contains('}')
-        );
-    }
-
-    #[test]
-    fn btreesets() {
-        use std::collections::BTreeSet;
+        use alloc::collections::BTreeSet;
 
         let set_i8 = (vec![3i8, 12i8, 24i8, 72i8]
             .into_iter()
@@ -480,8 +424,73 @@ mod test {
     }
 
     #[test]
+    fn btreesets() {
+        let set_i8 = (vec![3i8, 12i8, 24i8, 72i8]
+            .into_iter()
+            .collect::<BTreeSet<i8>>())
+        .serialize();
+        let set_u16 = (vec![3u16, 12u16, 24u16, 72u16]
+            .into_iter()
+            .collect::<BTreeSet<u16>>())
+        .serialize();
+        let set_i64 = (vec![3i64, 12i64, 24i64, 72i64]
+            .into_iter()
+            .collect::<BTreeSet<i64>>())
+        .serialize();
+        let set_bool = (vec![true, false].into_iter().collect::<BTreeSet<bool>>()).serialize();
+        let set_str = (vec!["aba", "cate", "azul"]
+            .into_iter()
+            .collect::<BTreeSet<&str>>())
+        .serialize();
+        let set_string = (vec!["aba".to_string(), "cate".to_string(), "azul".to_string()]
+            .into_iter()
+            .collect::<BTreeSet<String>>())
+        .serialize();
+
+        assert!(
+            set_i8.contains("#{")
+                && set_i8.contains(',')
+                && set_i8.contains('3')
+                && set_i8.contains('}')
+        );
+        assert!(
+            set_u16.contains("#{")
+                && set_u16.contains(',')
+                && set_u16.contains('3')
+                && set_u16.contains('}')
+        );
+        assert!(
+            set_i64.contains("#{")
+                && set_i64.contains(',')
+                && set_i64.contains('3')
+                && set_i64.contains('}')
+        );
+        assert!(
+            set_bool.contains("#{")
+                && set_bool.contains(',')
+                && set_bool.contains("true")
+                && set_bool.contains("false")
+                && set_bool.contains('}')
+        );
+        assert!(
+            set_str.contains("#{")
+                && set_str.contains(',')
+                && set_str.contains("\"aba\"")
+                && set_str.contains("\"cate\"")
+                && set_str.contains('}')
+        );
+        assert!(
+            set_string.contains("#{")
+                && set_string.contains(',')
+                && set_string.contains("\"aba\"")
+                && set_string.contains("\"cate\"")
+                && set_string.contains('}')
+        );
+    }
+
+    #[test]
     fn lists() {
-        use std::collections::LinkedList;
+        use alloc::collections::LinkedList;
 
         let list_i8 = (vec![3i8, 12i8, 24i8, 72i8]
             .into_iter()

--- a/tests/deserialize.rs
+++ b/tests/deserialize.rs
@@ -1,6 +1,9 @@
 #[cfg(test)]
 mod test {
-    use std::str::FromStr;
+    extern crate alloc;
+
+    use alloc::collections::BTreeMap;
+    use core::str::FromStr;
 
     use edn::Error;
     use edn_rs::{edn, from_edn, from_str, hmap, map, Edn, List, Map, Vector};
@@ -364,11 +367,12 @@ mod test {
             ":a".to_string() => vec![":val".to_string()],
             ":b".to_string() => vec![":value".to_string()]
         };
-        let map: std::collections::BTreeMap<String, Vec<String>> = from_edn(&ns_map).unwrap();
+        let map: BTreeMap<String, Vec<String>> = from_edn(&ns_map).unwrap();
         assert_eq!(map, expected);
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn deser_hashmap() {
         let ns_map = Edn::Map(Map::new(map! {
             ":a".to_string() => Edn::Bool(true),

--- a/tests/deserialize_sets.rs
+++ b/tests/deserialize_sets.rs
@@ -1,8 +1,10 @@
 #[cfg(feature = "sets")]
 #[cfg(test)]
 mod test {
-    use std::collections::BTreeSet;
-    use std::str::FromStr;
+    extern crate alloc;
+
+    use alloc::collections::BTreeSet;
+    use core::str::FromStr;
 
     use edn::{Error, List, Vector};
     use edn_rs::{edn, from_edn, from_str, hset, map, set, Edn, Map, Set};
@@ -216,6 +218,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn deser_hashset() {
         use ordered_float::OrderedFloat;
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,5 +1,9 @@
 #![recursion_limit = "512"]
 
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
 pub mod deserialize;
 pub mod deserialize_sets;
 pub mod emit;

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    extern crate alloc;
+
+    use alloc::collections::BTreeMap;
 
     use edn_rs::{edn, map, Edn, List, Map, Vector};
 

--- a/tests/parse_sets.rs
+++ b/tests/parse_sets.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "sets")]
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, BTreeSet};
+    extern crate alloc;
+
+    use alloc::collections::{BTreeMap, BTreeSet};
 
     use edn_rs::{edn, set, Edn, List, Map, Set, Vector};
 

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -1,8 +1,9 @@
 #[cfg(test)]
 mod tests {
+    use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+
     use edn_derive::Serialize;
     use edn_rs::{hmap, hset, map, set};
-    use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
     #[test]
     fn serializes_a_complex_structure() {


### PR DESCRIPTION
This ended up being a lot easier that I expected.

WIP example compiles with
`cargo build --release --target thumbv6m-none-eabi`

I'll make some better examples and probably make it a separate project. Things get really weird with the current examples and dev-dependencies, not to mention we can't run it anyway. I'll make sure to grab some dev boards from the office so I can make some real examples over the holidays. I'll probably write a tiny little lisp that controls some hardware via s-expressions over serial.