### PR TITLE
The crate is now `no_std` with no breaking changes with default-features. 

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,7 +25,7 @@ jobs:
       - name: test_lib_features
         run: cargo test --all-features --no-fail-fast
       - name: test_lib_no_default_features
-        run: cargo test --no-default-features --no-fail-fast
+        run: cargo test --features std --no-default-features --no-fail-fast
       - name: example_fast
         run: cargo test --examples --no-fail-fast
       - name: example_json_to_edn
@@ -35,7 +35,7 @@ jobs:
       - name: example_async
         run: cargo run --example async
       - name: example_no_sets
-        run: cargo run --example struct_from_str --no-default-features
+        run: cargo run --example struct_from_str --features std --no-default-features
 
   fmt:
       runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "Crate to parse and emit EDN"
 readme = "README.md"
 documentation = "https://docs.rs/edn-rs/"
 repository = "https://github.com/edn-rs/edn-rs"
-keywords = ["EDN"]
+keywords = ["EDN", "no_std"]
 license = "MIT"
 edition = "2021"
 
@@ -20,9 +20,10 @@ pedantic = "warn"
 nursery = "warn"
 
 [features]
-default = ["sets"]
+default = ["sets", "std"]
 json = ["regex"]
 sets = ["ordered-float"]
+std = []
 
 [dependencies]
 regex = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "edn-rs"
 version = "0.17.4"
-authors = ["Julia Naomi <jnboeira@outlook.com>",  "Eva Pace <eba.pachi@gmail.com>"]
+authors = ["Julia Naomi <jnboeira@outlook.com>",  "Eva Pace <eba.pachi@gmail.com>", "Kevin Nakamura <grinkers@grinkers.net>"]
 description = "Crate to parse and emit EDN"
 readme = "README.md"
 documentation = "https://docs.rs/edn-rs/"

--- a/README.md
+++ b/README.md
@@ -17,11 +17,27 @@ Current example usage in:
 
 ## Usage
 
-`Cargo.toml`
+### Default
+Includes features `std` and `sets`.
+
 ```toml
 [dependencies]
 edn-rs = "0.17.4"
 ```
+
+### no_std
+To use `edn-rs` without any additional dependencies, disable default features.
+`edn-rs` still relies on `alloc`. In no_std environments, you must supply your own `#[global_allocator]`
+
+```toml
+[dependencies]
+edn-rs = { version = "0.17.4", default-features = false }
+```
+
+### Optional features
+* `std`: Implements (de)serialization for Hashmap and HashSet; Also some floating point functionality.
+* `sets`: Implements (de)serialization for EDN sets. Depends on `ordered-float`.
+* `json`: Implements json->edn and edn->json conversions. Depends on `regex`.
 
 ## Simple time-only benchmarks of `edn-rs` against Clojure Edn
 * Link to benchmarks implementation [here](https://github.com/naomijub/edn-duration-benchmark/blob/master/README.md)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Crate to parse and emit EDN 
 * **This lib does not make effort to conform the EDN received to EDN Spec.** The lib that generated this EDN should be responsible for this. For more information on Edn Spec please visit: https://github.com/edn-format/edn.
 * MSRV (minimal supported rust version) is stable minus 2 versions. Once stable (1.0.0), the plan is to indefinitely maintain the MSRV.
-* Library is almost stable (1.0.0), just missing [issue-4](https://github.com/edn-rs/edn-rs/issues/4) to reach feature stability and possible bugfix for [equality rules](https://github.com/edn-rs/edn-rs/issues/95). **No breaking changes with default features are predicted**.
+* Current library maintainer is Kevin Nakamura (@Grinkers)
 
 Our **MTTA** (Mean time to acknowledge) is around `one day`; 
 <!---->

--- a/bb.edn
+++ b/bb.edn
@@ -3,12 +3,12 @@
                                 :requires ([babashka.fs :as fs])
                                 :task     (fs/delete-tree "target")}
   test_lib_features            (shell "cargo test --all-features --no-fail-fast")
-  test_lib_no_default_features (shell "cargo test --no-default-features --no-fail-fast")
+  test_lib_no_default_features (shell "cargo test --features std --no-default-features --no-fail-fast")
   example_fast                 (shell "cargo test --examples --no-fail-fast")
   example_json_to_edn          (shell "cargo test --example json_to_edn --features \"json\"")
   example_edn_to_json          (shell "cargo test --example edn_to_json --features \"json\"")
   example_async                (shell "cargo run --example async")
-  example_no_sets              (shell "cargo run --example struct_from_str --no-default-features")
+  example_no_sets              (shell "cargo run --example struct_from_str --features std --no-default-features")
   cargo-test                   {:doc     "Runs all cargo tests"
                                 :depends [test_lib_features test_lib_no_default_features example_fast
                                           example_json_to_edn example_edn_to_json example_edn_to_json

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -1,9 +1,18 @@
-use crate::edn::{Edn, Error};
-use std::collections::{BTreeMap, HashMap};
+use alloc::collections::BTreeMap;
 #[cfg(feature = "sets")]
-use std::collections::{BTreeSet, HashSet};
-use std::convert::TryFrom;
-use std::str::FromStr;
+use alloc::collections::BTreeSet;
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::any;
+use core::convert::{Into, TryFrom};
+use core::str::FromStr;
+#[cfg(feature = "std")]
+use std::collections::HashMap;
+#[cfg(all(feature = "sets", feature = "std"))]
+use std::collections::HashSet;
+
+use crate::edn::{Edn, Error};
 
 pub mod parse;
 
@@ -81,7 +90,7 @@ impl Deserialize for OrderedFloat<f64> {
     fn deserialize(edn: &Edn) -> Result<Self, Error> {
         edn.to_float()
             .ok_or_else(|| build_deserialize_error(edn, "edn_rs::Double"))
-            .map(std::convert::Into::into)
+            .map(Into::into)
     }
 }
 
@@ -89,7 +98,7 @@ impl Deserialize for f64 {
     fn deserialize(edn: &Edn) -> Result<Self, Error> {
         edn.to_float()
             .ok_or_else(|| build_deserialize_error(edn, "edn_rs::Double"))
-            .map(std::convert::Into::into)
+            .map(Into::into)
     }
 }
 
@@ -178,11 +187,12 @@ where
                 .ok_or_else(|| Error::Iter(format!("Could not create iter from {edn:?}")))?
                 .map(|e| Deserialize::deserialize(e))
                 .collect::<Result<Self, Error>>()?),
-            _ => Err(build_deserialize_error(edn, std::any::type_name::<Self>())),
+            _ => Err(build_deserialize_error(edn, any::type_name::<Self>())),
         }
     }
 }
 
+#[cfg(feature = "std")]
 impl<T, H> Deserialize for HashMap<String, T, H>
 where
     T: Deserialize,
@@ -205,7 +215,7 @@ where
                     ))
                 })
                 .collect::<Result<Self, Error>>(),
-            _ => Err(build_deserialize_error(edn, std::any::type_name::<Self>())),
+            _ => Err(build_deserialize_error(edn, any::type_name::<Self>())),
         }
     }
 }
@@ -231,12 +241,12 @@ where
                     ))
                 })
                 .collect::<Result<Self, Error>>(),
-            _ => Err(build_deserialize_error(edn, std::any::type_name::<Self>())),
+            _ => Err(build_deserialize_error(edn, any::type_name::<Self>())),
         }
     }
 }
 
-#[cfg(feature = "sets")]
+#[cfg(all(feature = "sets", feature = "std"))]
 impl<T, H> Deserialize for HashSet<T, H>
 where
     T: std::cmp::Eq + std::hash::Hash + Deserialize,
@@ -256,7 +266,7 @@ where
                     })
                 })
                 .collect::<Result<Self, Error>>(),
-            _ => Err(build_deserialize_error(edn, std::any::type_name::<Self>())),
+            _ => Err(build_deserialize_error(edn, any::type_name::<Self>())),
         }
     }
 }
@@ -264,7 +274,7 @@ where
 #[cfg(feature = "sets")]
 impl<T> Deserialize for BTreeSet<T>
 where
-    T: std::cmp::Eq + std::hash::Hash + std::cmp::Ord + Deserialize,
+    T: core::cmp::Eq + core::hash::Hash + core::cmp::Ord + Deserialize,
 {
     fn deserialize(edn: &Edn) -> Result<Self, Error> {
         match edn {
@@ -280,7 +290,7 @@ where
                     })
                 })
                 .collect::<Result<Self, Error>>(),
-            _ => Err(build_deserialize_error(edn, std::any::type_name::<Self>())),
+            _ => Err(build_deserialize_error(edn, any::type_name::<Self>())),
         }
     }
 }

--- a/src/edn/mod.rs
+++ b/src/edn/mod.rs
@@ -1,10 +1,16 @@
+use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+#[cfg(feature = "sets")]
+use alloc::collections::BTreeSet;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use alloc::{fmt, format};
+#[cfg(feature = "sets")]
+use core::cmp::{Ord, PartialOrd};
+use core::convert::{Infallible, TryFrom};
+use core::num;
+
 use crate::deserialize::parse::{self};
-#[cfg(feature = "sets")]
-use std::cmp::{Ord, PartialOrd};
-use std::collections::BTreeMap;
-#[cfg(feature = "sets")]
-use std::collections::BTreeSet;
-use std::convert::TryFrom;
 use utils::index::Index;
 
 #[cfg(feature = "sets")]
@@ -47,8 +53,8 @@ pub struct Double(pub(crate) OrderedFloat<f64>);
 #[cfg(not(feature = "sets"))]
 pub struct Double(f64);
 
-impl std::fmt::Display for Double {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Double {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
@@ -305,8 +311,10 @@ impl Edn {
             #[allow(clippy::cast_possible_wrap)]
             Self::UInt(u) if i64::try_from(*u).is_ok() => Some(*u as i64),
             #[allow(clippy::cast_possible_truncation)]
+            #[cfg(feature = "std")]
             Self::Double(d) => Some((*d).to_float().round() as i64),
             #[allow(clippy::cast_possible_truncation)]
+            #[cfg(feature = "std")]
             Self::Rational(r) => Some(rational_to_double(r).unwrap_or(0f64).round() as i64),
             _ => None,
         }
@@ -320,12 +328,14 @@ impl Edn {
             #[allow(clippy::cast_sign_loss)]
             Self::Int(i) if i > &0 => Some(*i as u64),
             Self::UInt(i) => Some(*i),
+            #[cfg(feature = "std")]
             Self::Double(d) if d.to_float() > 0f64 =>
             {
                 #[allow(clippy::cast_sign_loss)]
                 #[allow(clippy::cast_possible_truncation)]
                 Some((*d).to_float().round() as u64)
             }
+            #[cfg(feature = "std")]
             Self::Rational(r) if !r.contains('-') =>
             {
                 #[allow(clippy::cast_sign_loss)]
@@ -606,7 +616,7 @@ impl Edn {
     /// ```
     #[allow(clippy::needless_doctest_main)]
     #[must_use]
-    pub fn iter_some(&self) -> Option<std::slice::Iter<'_, Self>> {
+    pub fn iter_some(&self) -> Option<core::slice::Iter<'_, Self>> {
         match self {
             Self::Vector(v) => Some(v.0.iter()),
             Self::List(l) => Some(l.0.iter()),
@@ -618,7 +628,7 @@ impl Edn {
     /// Other types return `None`
     #[cfg(feature = "sets")]
     #[must_use]
-    pub fn set_iter(&self) -> Option<std::collections::btree_set::Iter<'_, Self>> {
+    pub fn set_iter(&self) -> Option<alloc::collections::btree_set::Iter<'_, Self>> {
         match self {
             Self::Set(s) => Some(s.0.iter()),
             _ => None,
@@ -628,7 +638,7 @@ impl Edn {
     /// `map_iter` returns am `Option<btree_map::Iter<String, Edn>>` with `Some` for type `Edn::Map`
     /// Other types return `None`
     #[must_use]
-    pub fn map_iter(&self) -> Option<std::collections::btree_map::Iter<'_, String, Self>> {
+    pub fn map_iter(&self) -> Option<alloc::collections::btree_map::Iter<'_, String, Self>> {
         match self {
             Self::Map(m) => Some(m.0.iter()),
             _ => None,
@@ -678,7 +688,7 @@ impl Edn {
     }
 }
 
-impl std::str::FromStr for Edn {
+impl core::str::FromStr for Edn {
     type Err = Error;
 
     /// Parses a `&str` that contains an Edn into `Result<Edn, EdnError>`
@@ -687,9 +697,9 @@ impl std::str::FromStr for Edn {
     }
 }
 
-fn to_double<T>(i: T) -> Result<f64, std::num::ParseFloatError>
+fn to_double<T>(i: T) -> Result<f64, num::ParseFloatError>
 where
-    T: std::fmt::Debug,
+    T: fmt::Debug,
 {
     format!("{i:?}").parse::<f64>()
 }
@@ -713,7 +723,7 @@ pub enum Error {
     ParseEdn(String),
     Deserialize(String),
     Iter(String),
-    TryFromInt(std::num::TryFromIntError),
+    TryFromInt(num::TryFromIntError),
     #[doc(hidden)]
     Infallable(), // Makes the compiler happy for converting u64 to u64 and i64 to i64
 }
@@ -724,38 +734,38 @@ impl From<String> for Error {
     }
 }
 
-impl From<std::num::ParseIntError> for Error {
-    fn from(s: std::num::ParseIntError) -> Self {
+impl From<num::ParseIntError> for Error {
+    fn from(s: num::ParseIntError) -> Self {
         Self::ParseEdn(s.to_string())
     }
 }
 
-impl From<std::num::ParseFloatError> for Error {
-    fn from(s: std::num::ParseFloatError) -> Self {
+impl From<num::ParseFloatError> for Error {
+    fn from(s: num::ParseFloatError) -> Self {
         Self::ParseEdn(s.to_string())
     }
 }
 
-impl From<std::str::ParseBoolError> for Error {
-    fn from(s: std::str::ParseBoolError) -> Self {
+impl From<core::str::ParseBoolError> for Error {
+    fn from(s: core::str::ParseBoolError) -> Self {
         Self::ParseEdn(s.to_string())
     }
 }
 
-impl From<std::num::TryFromIntError> for Error {
-    fn from(e: std::num::TryFromIntError) -> Self {
+impl From<num::TryFromIntError> for Error {
+    fn from(e: num::TryFromIntError) -> Self {
         Self::TryFromInt(e)
     }
 }
 
-impl From<std::convert::Infallible> for Error {
-    fn from(_: std::convert::Infallible) -> Self {
+impl From<Infallible> for Error {
+    fn from(_: Infallible) -> Self {
         Self::Infallable()
     }
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::ParseEdn(s) | Self::Deserialize(s) | Self::Iter(s) => write!(f, "{}", &s),
             Self::TryFromInt(e) => write!(f, "{e}"),
@@ -766,6 +776,9 @@ impl std::fmt::Display for Error {
 
 #[cfg(test)]
 mod test {
+    use alloc::borrow::ToOwned;
+    use alloc::vec;
+
     use super::*;
     #[test]
     fn parses_rationals() {

--- a/src/edn/utils/index.rs
+++ b/src/edn/utils/index.rs
@@ -1,6 +1,9 @@
+use alloc::borrow::ToOwned;
+use alloc::string::{String, ToString};
+use core::convert::TryFrom;
+use core::{fmt, ops};
+
 use crate::edn::{Edn, Map};
-use std::convert::TryFrom;
-use std::{fmt, ops};
 
 /// This is a Copy of [`Serde_json::index`](https://docs.serde.rs/src/serde_json/value/index.rs.html)
 pub trait Index: private::Sealed {
@@ -63,7 +66,7 @@ impl Index for str {
     }
     fn index_or_insert<'v>(&self, v: &'v mut Edn) -> &'v mut Edn {
         if *v == Edn::Nil {
-            *v = Edn::Map(Map::new(std::collections::BTreeMap::new()));
+            *v = Edn::Map(Map::new(alloc::collections::BTreeMap::new()));
         }
         match *v {
             Edn::Map(ref mut map) => map.0.entry(self.to_owned()).or_insert(Edn::Nil),
@@ -120,6 +123,8 @@ where
 
 // Prevent users from implementing the Index trait.
 mod private {
+    use alloc::string::String;
+
     use crate::Edn;
 
     pub trait Sealed {}

--- a/src/edn/utils/mod.rs
+++ b/src/edn/utils/mod.rs
@@ -1,3 +1,6 @@
+use alloc::format;
+use alloc::string::{String, ToString};
+
 pub mod index;
 
 pub trait Attribute {

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -1,3 +1,10 @@
+use alloc::collections::BTreeMap;
+#[cfg(feature = "sets")]
+use alloc::collections::BTreeSet;
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
 use crate::edn::{rational_to_double, Edn};
 
 #[allow(clippy::module_name_repetitions)]
@@ -70,7 +77,7 @@ fn vec_to_json(vec: &[Edn]) -> String {
 }
 
 #[cfg(feature = "sets")]
-fn set_to_json_vec(set: &std::collections::BTreeSet<Edn>) -> String {
+fn set_to_json_vec(set: &BTreeSet<Edn>) -> String {
     let set_str = set
         .iter()
         .map(display_as_json)
@@ -82,7 +89,7 @@ fn set_to_json_vec(set: &std::collections::BTreeSet<Edn>) -> String {
     s
 }
 
-fn map_to_json(map: &std::collections::BTreeMap<String, Edn>) -> String {
+fn map_to_json(map: &BTreeMap<String, Edn>) -> String {
     let map_str = map
         .iter()
         .map(|(k, e)| {
@@ -105,6 +112,9 @@ fn map_to_json(map: &std::collections::BTreeMap<String, Edn>) -> String {
 
 #[cfg(test)]
 mod test {
+    use alloc::boxed::Box;
+    use alloc::vec;
+
     use super::*;
     use crate::edn::{Edn, List, Map, Set, Vector};
     use crate::{map, set};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,14 @@
+#![no_std]
 #![recursion_limit = "512"]
+
 #[macro_use]
 mod macros;
+
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+use alloc::string::String;
 
 /// Edn type implementation
 pub mod edn;
@@ -38,7 +46,9 @@ pub mod serialize;
 pub(crate) mod json;
 
 #[cfg(feature = "json")]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
+#[cfg(feature = "json")]
+use alloc::string::ToString;
 
 mod deserialize;
 /// `json_to_edn` receives a json string and parses its common key-values to a regular EDN format. It requires feature `json`

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -273,7 +273,8 @@ macro_rules! edn_unexpected {
 macro_rules! map(
     { $($key:expr => $value:expr),+ } => {
         {
-            let mut m = std::collections::BTreeMap::new();
+            extern crate alloc;
+            let mut m = alloc::collections::BTreeMap::new();
             $(
                 m.insert($key, $value);
             )+
@@ -288,7 +289,8 @@ macro_rules! map(
 macro_rules! set {
     ($($x:expr),+ $(,)?) => (
         {
-            let mut s = std::collections::BTreeSet::new();
+            extern crate alloc;
+            let mut s = alloc::collections::BTreeSet::new();
             $(
                 s.insert($x);
             )*
@@ -300,6 +302,7 @@ macro_rules! set {
 /// Creates a `HashMap` from a seq of `$key => $value, `
 /// `hmap!{a => "b", c => "d"}`
 #[macro_export]
+#[cfg(feature = "std")]
 macro_rules! hmap(
     { $($key:expr => $value:expr),+ } => {
         {
@@ -315,6 +318,7 @@ macro_rules! hmap(
 /// Creates a `HashSet` from a seq of `$x, `
 /// `set!{1, 2, 3, 4}`
 #[macro_export]
+#[cfg(feature = "std")]
 macro_rules! hset {
     ($($x:expr),+ $(,)?) => (
         {

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -1,3 +1,8 @@
+use alloc::collections::{BTreeMap, BTreeSet, LinkedList};
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
 /// Trait that allows you to implement Serialization for each type of your choice.
 /// Example:
 /// ```rust
@@ -48,6 +53,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T, H: std::hash::BuildHasher> Serialize for std::collections::HashSet<T, H>
 where
     T: Serialize,
@@ -66,7 +72,7 @@ where
     }
 }
 
-impl<T> Serialize for std::collections::BTreeSet<T>
+impl<T> Serialize for BTreeSet<T>
 where
     T: Serialize,
 {
@@ -84,7 +90,7 @@ where
     }
 }
 
-impl<T> Serialize for std::collections::LinkedList<T>
+impl<T> Serialize for LinkedList<T>
 where
     T: Serialize,
 {
@@ -101,6 +107,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T, H: std::hash::BuildHasher> Serialize for std::collections::HashMap<String, T, H>
 where
     T: Serialize,
@@ -118,6 +125,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T, H: ::std::hash::BuildHasher> Serialize for std::collections::HashMap<&str, T, H>
 where
     T: Serialize,
@@ -135,7 +143,7 @@ where
     }
 }
 
-impl<T> Serialize for std::collections::BTreeMap<String, T>
+impl<T> Serialize for BTreeMap<String, T>
 where
     T: Serialize,
 {
@@ -152,7 +160,7 @@ where
     }
 }
 
-impl<T> Serialize for std::collections::BTreeMap<&str, T>
+impl<T> Serialize for BTreeMap<&str, T>
 where
     T: Serialize,
 {
@@ -283,6 +291,9 @@ impl<A: Serialize, B: Serialize, C: Serialize, D: Serialize, E: Serialize, F: Se
 
 #[cfg(test)]
 mod test {
+    use alloc::collections::BTreeSet;
+    use alloc::vec;
+
     use super::*;
 
     #[test]
@@ -347,74 +358,7 @@ mod test {
 
     #[test]
     fn hashsets() {
-        use std::collections::HashSet;
-
-        let set_i8 = (vec![3i8, 12i8, 24i8, 72i8]
-            .into_iter()
-            .collect::<HashSet<i8>>())
-        .serialize();
-        let set_u16 = (vec![3u16, 12u16, 24u16, 72u16]
-            .into_iter()
-            .collect::<HashSet<u16>>())
-        .serialize();
-        let set_i64 = (vec![3i64, 12i64, 24i64, 72i64]
-            .into_iter()
-            .collect::<HashSet<i64>>())
-        .serialize();
-        let set_bool = (vec![true, false].into_iter().collect::<HashSet<bool>>()).serialize();
-        let set_str = (vec!["aba", "cate", "azul"]
-            .into_iter()
-            .collect::<HashSet<&str>>())
-        .serialize();
-        let set_string = (vec!["aba".to_string(), "cate".to_string(), "azul".to_string()]
-            .into_iter()
-            .collect::<HashSet<String>>())
-        .serialize();
-
-        assert!(
-            set_i8.contains("#{")
-                && set_i8.contains(',')
-                && set_i8.contains('3')
-                && set_i8.contains('}')
-        );
-        assert!(
-            set_u16.contains("#{")
-                && set_u16.contains(',')
-                && set_u16.contains('3')
-                && set_u16.contains('}')
-        );
-        assert!(
-            set_i64.contains("#{")
-                && set_i64.contains(',')
-                && set_i64.contains('3')
-                && set_i64.contains('}')
-        );
-        assert!(
-            set_bool.contains("#{")
-                && set_bool.contains(',')
-                && set_bool.contains("true")
-                && set_bool.contains("false")
-                && set_bool.contains('}')
-        );
-        assert!(
-            set_str.contains("#{")
-                && set_str.contains(',')
-                && set_str.contains("\"aba\"")
-                && set_str.contains("\"cate\"")
-                && set_str.contains('}')
-        );
-        assert!(
-            set_string.contains("#{")
-                && set_string.contains(',')
-                && set_string.contains("\"aba\"")
-                && set_string.contains("\"cate\"")
-                && set_string.contains('}')
-        );
-    }
-
-    #[test]
-    fn btreesets() {
-        use std::collections::BTreeSet;
+        use alloc::collections::BTreeSet;
 
         let set_i8 = (vec![3i8, 12i8, 24i8, 72i8]
             .into_iter()
@@ -480,8 +424,73 @@ mod test {
     }
 
     #[test]
+    fn btreesets() {
+        let set_i8 = (vec![3i8, 12i8, 24i8, 72i8]
+            .into_iter()
+            .collect::<BTreeSet<i8>>())
+        .serialize();
+        let set_u16 = (vec![3u16, 12u16, 24u16, 72u16]
+            .into_iter()
+            .collect::<BTreeSet<u16>>())
+        .serialize();
+        let set_i64 = (vec![3i64, 12i64, 24i64, 72i64]
+            .into_iter()
+            .collect::<BTreeSet<i64>>())
+        .serialize();
+        let set_bool = (vec![true, false].into_iter().collect::<BTreeSet<bool>>()).serialize();
+        let set_str = (vec!["aba", "cate", "azul"]
+            .into_iter()
+            .collect::<BTreeSet<&str>>())
+        .serialize();
+        let set_string = (vec!["aba".to_string(), "cate".to_string(), "azul".to_string()]
+            .into_iter()
+            .collect::<BTreeSet<String>>())
+        .serialize();
+
+        assert!(
+            set_i8.contains("#{")
+                && set_i8.contains(',')
+                && set_i8.contains('3')
+                && set_i8.contains('}')
+        );
+        assert!(
+            set_u16.contains("#{")
+                && set_u16.contains(',')
+                && set_u16.contains('3')
+                && set_u16.contains('}')
+        );
+        assert!(
+            set_i64.contains("#{")
+                && set_i64.contains(',')
+                && set_i64.contains('3')
+                && set_i64.contains('}')
+        );
+        assert!(
+            set_bool.contains("#{")
+                && set_bool.contains(',')
+                && set_bool.contains("true")
+                && set_bool.contains("false")
+                && set_bool.contains('}')
+        );
+        assert!(
+            set_str.contains("#{")
+                && set_str.contains(',')
+                && set_str.contains("\"aba\"")
+                && set_str.contains("\"cate\"")
+                && set_str.contains('}')
+        );
+        assert!(
+            set_string.contains("#{")
+                && set_string.contains(',')
+                && set_string.contains("\"aba\"")
+                && set_string.contains("\"cate\"")
+                && set_string.contains('}')
+        );
+    }
+
+    #[test]
     fn lists() {
-        use std::collections::LinkedList;
+        use alloc::collections::LinkedList;
 
         let list_i8 = (vec![3i8, 12i8, 24i8, 72i8]
             .into_iter()

--- a/tests/deserialize.rs
+++ b/tests/deserialize.rs
@@ -1,6 +1,9 @@
 #[cfg(test)]
 mod test {
-    use std::str::FromStr;
+    extern crate alloc;
+
+    use alloc::collections::BTreeMap;
+    use core::str::FromStr;
 
     use edn::Error;
     use edn_rs::{edn, from_edn, from_str, hmap, map, Edn, List, Map, Vector};
@@ -364,11 +367,12 @@ mod test {
             ":a".to_string() => vec![":val".to_string()],
             ":b".to_string() => vec![":value".to_string()]
         };
-        let map: std::collections::BTreeMap<String, Vec<String>> = from_edn(&ns_map).unwrap();
+        let map: BTreeMap<String, Vec<String>> = from_edn(&ns_map).unwrap();
         assert_eq!(map, expected);
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn deser_hashmap() {
         let ns_map = Edn::Map(Map::new(map! {
             ":a".to_string() => Edn::Bool(true),

--- a/tests/deserialize_sets.rs
+++ b/tests/deserialize_sets.rs
@@ -1,8 +1,10 @@
 #[cfg(feature = "sets")]
 #[cfg(test)]
 mod test {
-    use std::collections::BTreeSet;
-    use std::str::FromStr;
+    extern crate alloc;
+
+    use alloc::collections::BTreeSet;
+    use core::str::FromStr;
 
     use edn::{Error, List, Vector};
     use edn_rs::{edn, from_edn, from_str, hset, map, set, Edn, Map, Set};
@@ -216,6 +218,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn deser_hashset() {
         use ordered_float::OrderedFloat;
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,5 +1,9 @@
 #![recursion_limit = "512"]
 
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
 pub mod deserialize;
 pub mod deserialize_sets;
 pub mod emit;

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    extern crate alloc;
+
+    use alloc::collections::BTreeMap;
 
     use edn_rs::{edn, map, Edn, List, Map, Vector};
 

--- a/tests/parse_sets.rs
+++ b/tests/parse_sets.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "sets")]
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, BTreeSet};
+    extern crate alloc;
+
+    use alloc::collections::{BTreeMap, BTreeSet};
 
     use edn_rs::{edn, set, Edn, List, Map, Set, Vector};
 

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -1,8 +1,9 @@
 #[cfg(test)]
 mod tests {
+    use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+
     use edn_derive::Serialize;
     use edn_rs::{hmap, hset, map, set};
-    use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
     #[test]
     fn serializes_a_complex_structure() {


### PR DESCRIPTION
(Edited a second time, after running on real hardware)

This ended up being a lot easier than I expected. The one breaking change is anybody using `--no-default-features` (likely only me, introduced only recently with `sets`) probably wants to add `--features std`.

https://github.com/Grinkers/pico-edn/blob/main/pico-edn/src/lib.rs
It runs on real hardware!

`dev-dependencies` rely on std, so things get really weird with examples. We couldn't run them anyway, so I think examples should live in a separate repo. Running tests and test coverage is also likely going to be really hard/impractical. We still test everything, logically, with a std env though.

I'll probably write a tiny little lisp that controls some hardware via s-expressions over serial as a more complete example for the org.

I think this is ready. Any thoughts? 