### PR TITLE
trait Serialize uses reference to self instead of move.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { version = "1.33", features = ["full"] }
 criterion = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-edn-derive = "0.5.0"
+edn-derive = { git = "https://github.com/Grinkers/edn-derive.git" } # TODO pin to proper release 
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/benches/serialize.rs
+++ b/benches/serialize.rs
@@ -46,11 +46,12 @@ mod edn {
     use criterion::Criterion;
     use edn_derive::Serialize;
 
-    use edn_rs::{map, set};
+    use edn_rs::{map, set, Serialize};
     use std::collections::{BTreeMap, BTreeSet};
 
     pub fn criterion_benchmark(c: &mut Criterion) {
-        c.bench_function("edn", |b| b.iter(|| edn_rs::to_string(val())));
+        let val = val();
+        c.bench_function("edn", |b| b.iter(|| val.serialize()));
     }
 
     fn val() -> ValEdn {

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -29,7 +29,7 @@ fn serialize() -> String {
         nothing: (),
     };
 
-    edn_rs::to_string(edn)
+    edn_rs::to_string(&edn)
 }
 
 fn main() {

--- a/examples/simple_serialize.rs
+++ b/examples/simple_serialize.rs
@@ -1,0 +1,31 @@
+use edn_rs::Serialize;
+
+struct Foo<'a> {
+    value: u64,
+    say: &'a str,
+}
+
+impl Serialize for Foo<'_> {
+    fn serialize(&self) -> String {
+        format!("{{:value {}, :say {:?}}}", self.value, self.say)
+    }
+}
+
+fn serialize() -> String {
+    let say = "Hello, World!";
+    let foo = Foo {
+        value: 42,
+        say: say,
+    };
+
+    foo.serialize()
+}
+
+fn main() {
+    println!("{}", serialize());
+}
+
+#[test]
+fn test_serialize() {
+    assert_eq!(serialize(), "{:value 42, :say \"Hello, World!\"}");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub mod edn;
 ///         set: set!{3i64, 4i64, 5i64},
 ///         tuples: (3i32, true, 'd')
 ///     };
-///     println!("{}", edn_rs::to_string(edn));
+///     println!("{}", edn_rs::to_string(&edn));
 ///     // { :map {:this-is-a-key ["with", "many", "keys"]}, :set #{3, 4, 5}, :tuples (3, true, \d), }
 /// }
 ///```
@@ -129,11 +129,11 @@ pub use serialize::Serialize;
 ///         set: set!{3i64, 4i64, 5i64},
 ///         tuples: (3i32, true, 'd')
 ///     };
-///     println!("{}", edn_rs::to_string(edn));
+///     println!("{}", edn_rs::to_string(&edn));
 ///     // { :map {:this-is-a-key ["with", "many", "keys"]}, :set #{3, 4, 5}, :tuples (3, true, \d), }
 /// }
 ///```
 #[allow(clippy::needless_doctest_main)]
-pub fn to_string<T: Serialize>(t: T) -> String {
+pub fn to_string<T: Serialize>(t: &T) -> String {
     t.serialize()
 }

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -12,7 +12,7 @@ use alloc::vec::Vec;
 /// struct YourType;
 ///
 /// impl Serialize for YourType {
-///     fn serialize(self) -> String {
+///     fn serialize(&self) -> String {
 ///         format!("{:?}", self)
 ///     }
 /// }
@@ -20,7 +20,7 @@ use alloc::vec::Vec;
 ///
 /// Implemented for all generic types.
 pub trait Serialize {
-    fn serialize(self) -> String;
+    fn serialize(&self) -> String;
 }
 
 macro_rules! ser_primitives {
@@ -28,7 +28,7 @@ macro_rules! ser_primitives {
         $(
             impl Serialize for $name
             {
-                fn serialize(self) -> String {
+                fn serialize(&self) -> String {
                     format!("{:?}", self)
                 }
             }
@@ -40,9 +40,9 @@ impl<T> Serialize for Vec<T>
 where
     T: Serialize,
 {
-    fn serialize(self) -> String {
+    fn serialize(&self) -> String {
         let aux_vec = self
-            .into_iter()
+            .iter()
             .map(Serialize::serialize)
             .collect::<Vec<String>>();
         let mut s = String::new();
@@ -58,9 +58,9 @@ impl<T, H: std::hash::BuildHasher> Serialize for std::collections::HashSet<T, H>
 where
     T: Serialize,
 {
-    fn serialize(self) -> String {
+    fn serialize(&self) -> String {
         let aux_vec = self
-            .into_iter()
+            .iter()
             .map(Serialize::serialize)
             .collect::<Vec<String>>();
         let mut s = String::new();
@@ -76,9 +76,9 @@ impl<T> Serialize for BTreeSet<T>
 where
     T: Serialize,
 {
-    fn serialize(self) -> String {
+    fn serialize(&self) -> String {
         let aux_vec = self
-            .into_iter()
+            .iter()
             .map(Serialize::serialize)
             .collect::<Vec<String>>();
         let mut s = String::new();
@@ -94,9 +94,9 @@ impl<T> Serialize for LinkedList<T>
 where
     T: Serialize,
 {
-    fn serialize(self) -> String {
+    fn serialize(&self) -> String {
         let aux_vec = self
-            .into_iter()
+            .iter()
             .map(Serialize::serialize)
             .collect::<Vec<String>>();
         let mut s = String::new();
@@ -112,9 +112,9 @@ impl<T, H: std::hash::BuildHasher> Serialize for std::collections::HashMap<Strin
 where
     T: Serialize,
 {
-    fn serialize(self) -> String {
+    fn serialize(&self) -> String {
         let aux_vec = self
-            .into_iter()
+            .iter()
             .map(|(k, v)| format!(":{} {}", k.replace([' ', '_'], "-"), v.serialize()))
             .collect::<Vec<String>>();
         let mut s = String::new();
@@ -130,9 +130,9 @@ impl<T, H: ::std::hash::BuildHasher> Serialize for std::collections::HashMap<&st
 where
     T: Serialize,
 {
-    fn serialize(self) -> String {
+    fn serialize(&self) -> String {
         let aux_vec = self
-            .into_iter()
+            .iter()
             .map(|(k, v)| format!(":{} {}", k.replace([' ', '_'], "-"), v.serialize()))
             .collect::<Vec<String>>();
         let mut s = String::new();
@@ -147,9 +147,9 @@ impl<T> Serialize for BTreeMap<String, T>
 where
     T: Serialize,
 {
-    fn serialize(self) -> String {
+    fn serialize(&self) -> String {
         let aux_vec = self
-            .into_iter()
+            .iter()
             .map(|(k, v)| format!(":{} {}", k.replace([' ', '_'], "-"), v.serialize()))
             .collect::<Vec<String>>();
         let mut s = String::new();
@@ -164,16 +164,10 @@ impl<T> Serialize for BTreeMap<&str, T>
 where
     T: Serialize,
 {
-    fn serialize(self) -> String {
+    fn serialize(&self) -> String {
         let aux_vec = self
-            .into_iter()
-            .map(|(k, v)| {
-                format!(
-                    ":{} {}",
-                    k.to_string().replace([' ', '_'], "-"),
-                    v.serialize()
-                )
-            })
+            .iter()
+            .map(|(k, v)| format!(":{} {}", k.replace([' ', '_'], "-"), v.serialize()))
             .collect::<Vec<String>>();
         let mut s = String::new();
         s.push('{');
@@ -187,25 +181,25 @@ where
 ser_primitives![i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, f32, f64, bool];
 
 impl Serialize for () {
-    fn serialize(self) -> String {
+    fn serialize(&self) -> String {
         "nil".to_string()
     }
 }
 
 impl Serialize for String {
-    fn serialize(self) -> String {
+    fn serialize(&self) -> String {
         format!("{self:?}")
     }
 }
 
 impl Serialize for &str {
-    fn serialize(self) -> String {
+    fn serialize(&self) -> String {
         format!("{self:?}")
     }
 }
 
 impl Serialize for char {
-    fn serialize(self) -> String {
+    fn serialize(&self) -> String {
         format!("\\{self}")
     }
 }
@@ -214,8 +208,8 @@ impl<T> Serialize for Option<T>
 where
     T: Serialize,
 {
-    fn serialize(self) -> String {
-        self.map_or_else(
+    fn serialize(&self) -> String {
+        self.as_ref().map_or_else(
             || String::from("nil"),
             crate::serialize::Serialize::serialize,
         )
@@ -224,19 +218,19 @@ where
 
 // Complex types
 impl<A: Serialize> Serialize for (A,) {
-    fn serialize(self) -> String {
+    fn serialize(&self) -> String {
         format!("({})", self.0.serialize())
     }
 }
 
 impl<A: Serialize, B: Serialize> Serialize for (A, B) {
-    fn serialize(self) -> String {
+    fn serialize(&self) -> String {
         format!("({}, {})", self.0.serialize(), self.1.serialize())
     }
 }
 
 impl<A: Serialize, B: Serialize, C: Serialize> Serialize for (A, B, C) {
-    fn serialize(self) -> String {
+    fn serialize(&self) -> String {
         format!(
             "({}, {}, {})",
             self.0.serialize(),
@@ -247,7 +241,7 @@ impl<A: Serialize, B: Serialize, C: Serialize> Serialize for (A, B, C) {
 }
 
 impl<A: Serialize, B: Serialize, C: Serialize, D: Serialize> Serialize for (A, B, C, D) {
-    fn serialize(self) -> String {
+    fn serialize(&self) -> String {
         format!(
             "({}, {}, {}, {})",
             self.0.serialize(),
@@ -261,7 +255,7 @@ impl<A: Serialize, B: Serialize, C: Serialize, D: Serialize> Serialize for (A, B
 impl<A: Serialize, B: Serialize, C: Serialize, D: Serialize, E: Serialize> Serialize
     for (A, B, C, D, E)
 {
-    fn serialize(self) -> String {
+    fn serialize(&self) -> String {
         format!(
             "({}, {}, {}, {}, {})",
             self.0.serialize(),
@@ -276,7 +270,7 @@ impl<A: Serialize, B: Serialize, C: Serialize, D: Serialize, E: Serialize> Seria
 impl<A: Serialize, B: Serialize, C: Serialize, D: Serialize, E: Serialize, F: Serialize> Serialize
     for (A, B, C, D, E, F)
 {
-    fn serialize(self) -> String {
+    fn serialize(&self) -> String {
         format!(
             "({}, {}, {}, {}, {}, {})",
             self.0.serialize(),

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -24,7 +24,7 @@ mod tests {
             tuples: (3i32, true, 'd'),
         };
 
-        assert_eq!(edn_rs::to_string(edn), "{ :btreemap {:this-is-a-key [\"with\", \"many\", \"keys\"]}, :btreeset #{3, 4, 5}, :hashmap {:this-is-a-key [\"with\", \"many\", \"keys\"]}, :hashset #{3}, :tuples (3, true, \\d), }");
+        assert_eq!(edn_rs::to_string(&edn), "{ :btreemap {:this-is-a-key [\"with\", \"many\", \"keys\"]}, :btreeset #{3, 4, 5}, :hashmap {:this-is-a-key [\"with\", \"many\", \"keys\"]}, :hashset #{3}, :tuples (3, true, \\d), }");
     }
 
     #[test]
@@ -54,7 +54,7 @@ mod tests {
             },
         };
 
-        assert_eq!(edn_rs::to_string(edn), "{ :value 3.4, :bar { :value \"data\", :foo-vec [{ :value false, }, { :value true, }], }, }");
+        assert_eq!(edn_rs::to_string(&edn), "{ :value 3.4, :bar { :value \"data\", :foo-vec [{ :value false, }, { :value true, }], }, }");
     }
 }
 


### PR DESCRIPTION
This is a breaking change to Serialize and `edn-derive`. See https://github.com/edn-rs/edn-derive/pull/37 for compatibility. Clean-history version of https://github.com/edn-rs/edn-rs/pull/137

Rationale:
We want to be able to do things like
```rust
// assume some valid struct `val`
let s1 = val.serialize();
val.foobar = 42;
let s2 = val.serialize();
```

It is both annoying and potentially very expensive to move the struct, deallocate, and then create a whole new one each time you may want to serialize. If your Serializable data is inside of another struct, that requires a huge amount of work (making sure things can be `Clone`d, do deep copies, etc just to free it immediately after. In embedded this is probably critical, as you'll need the original, clone, and string data before starting to clean up, so max memory usage will high.

As far as performance goes
https://github.com/edn-rs/edn-rs/pull/144/files#diff-684ad70dd994bef2eaab407a0147b7b4ec3922c586fa15f9fe015d848abfc963L53-R54
```
edn                  time:   [2.8078 µs 2.8699 µs 2.9567 µs]
                        change: [-46.116% -44.053% -41.986%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  6 (6.00%) high mild
  9 (9.00%) high severe
  ```
This shows how expensive move vs borrow is (will continue to scale up depending on size).