### PR TITLE
Edn::Rational from String to (i64, u64).

### DIFF
--- a/examples/to_vec.rs
+++ b/examples/to_vec.rs
@@ -5,7 +5,7 @@ fn to_vec() {
     let v = Edn::List(List::new(vec![
         Edn::Key(":my-key".to_string()),
         Edn::Int(6),
-        Edn::Rational("7/4".to_string()),
+        Edn::Rational((7, 4)),
     ]));
 
     println!("{:?}", v.to_vec().unwrap());

--- a/examples/tokenize_edn.rs
+++ b/examples/tokenize_edn.rs
@@ -12,7 +12,7 @@ fn tokenize() {
         Edn::Bool(false),
         Edn::Key(":f".to_string()),
         Edn::Nil,
-        Edn::Rational("3/4".to_string()),
+        Edn::Rational((3, 4)),
     ]));
 
     println!("{edn:?}");

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -28,7 +28,7 @@ pub fn display_as_json(edn: &Edn) -> String {
             }
             s
         }
-        Edn::Rational(r) => format!("{}", rational_to_double(r).unwrap()),
+        Edn::Rational(r) => format!("{}", rational_to_double(*r)),
         Edn::Char(c) => format!("'{c}'"),
         Edn::Bool(b) => format!("{b}"),
         Edn::Nil => String::from("null"),
@@ -142,11 +142,11 @@ mod test {
     #[test]
     fn rational_numbers() {
         assert_eq!(
-            display_as_json(&Edn::Rational("3/4".to_string())),
+            display_as_json(&Edn::Rational((3, 4))),
             String::from("0.75")
         );
         assert_eq!(
-            display_as_json(&Edn::Rational("-3/9".to_string())),
+            display_as_json(&Edn::Rational((-3, 9))),
             String::from("-0.3333333333333333")
         );
     }
@@ -189,7 +189,7 @@ mod test {
             Edn::Key(":b".to_string()),
             Edn::Str("test".to_string()),
             Edn::Char('4'),
-            Edn::Rational("-3/4".to_string()),
+            Edn::Rational((-3, 4)),
             Edn::Double(4.5f64.into()),
             Edn::UInt(4),
         ]));
@@ -206,7 +206,7 @@ mod test {
             Edn::Key(":b".to_string()),
             Edn::Str("test".to_string()),
             Edn::Char('4'),
-            Edn::Rational("-3/4".to_string()),
+            Edn::Rational((-3, 4)),
             Edn::Double(4.5f64.into()),
             Edn::UInt(4),
         ]));
@@ -223,7 +223,7 @@ mod test {
             Edn::Key(":my-bestie".to_string()),
             Edn::Str("test".to_string()),
             Edn::Char('4'),
-            Edn::Rational("-3/4".to_string()),
+            Edn::Rational((-3, 4)),
             Edn::Double(4.5f64.into()),
             Edn::UInt(4),
         ]));
@@ -238,7 +238,7 @@ mod test {
     fn simple_map() {
         let map = Edn::Map(Map::new(map! {
             String::from("1.2") => Edn::Bool(false),
-            String::from(":belo-monte") => Edn::Rational(String::from("3/4")),
+            String::from(":belo-monte") => Edn::Rational((3, 4)),
             String::from("true") => Edn::Char('d')
         }));
 
@@ -258,14 +258,14 @@ mod test {
                 Edn::Bool(false),
                 Edn::Key(":f".to_string()),
                 Edn::Nil,
-                Edn::Rational("3/4".to_string()),
+                Edn::Rational((3, 4)),
                 Edn::Set(Set::new(set! {
-                    Edn::Rational("3/4".to_string())
+                    Edn::Rational((3, 4))
                 })),
             ])),
             Edn::Map(Map::new(map![
                     String::from("false") => Edn::Key(":f".to_string()),
-                    String::from("nil") => Edn::Rational("3/4".to_string()),
+                    String::from("nil") => Edn::Rational((3, 4)),
                     String::from(":my-crazy-map") => Edn::Map(Map::new(map![
                         String::from("false") => Edn::Map(
                             Map::new( map![
@@ -273,7 +273,7 @@ mod test {
                             ])),
                         String::from("nil") => Edn::Vector(
                             Vector::new( vec![
-                                Edn::Rational("3/4".to_string()),
+                                Edn::Rational((3, 4)),
                                 Edn::Int(1i64)
                             ]))
                 ]))
@@ -293,7 +293,7 @@ mod test {
                 Edn::Key(":b".to_string()),
                 Edn::Str("test".to_string()),
                 Edn::Char('4'),
-                Edn::Rational("-3/4".to_string()),
+                Edn::Rational((-3, 4)),
                 Edn::Double(4.5f64.into()),
                 Edn::UInt(4),
             ]))),

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -21,7 +21,7 @@
 ///                     Edn::Bool(false),
 ///                     Edn::Key(":f".to_string()),
 ///                     Edn::Nil,
-///                     Edn::Rational("3/4".to_string())
+///                     Edn::Rational((3, 4))
 ///                 ]
 ///             )
 ///         );
@@ -38,7 +38,7 @@
 ///             Edn::Bool(false),
 ///             Edn::Key(":f".to_string()),
 ///             Edn::Nil,
-///             Edn::Rational("3/4".to_string())
+///             Edn::Rational((3, 4))
 ///             }
 ///         )
 ///     );
@@ -50,7 +50,7 @@
 ///             map!{
 ///                 String::from("1.2") => Edn::Bool(false),
 ///                 // Note `:b` becomes `b`
-///                 String::from(":b") => Edn::Rational(String::from("3/4"))
+///                 String::from(":b") => Edn::Rational((3, 4))
 ///             }
 ///         )
 ///     );
@@ -81,7 +81,7 @@
 ///                         ])),
 ///                     String::from("nil") => Edn::Vector(
 ///                         Vector::new( vec![
-///                             Edn::Rational("3/4".to_string()),
+///                             Edn::Rational((3, 4)),
 ///                             Edn::Int(1i64)
 ///                         ]))
 ///             ]))
@@ -200,8 +200,7 @@ macro_rules! edn_internal {
     };
 
     ($num:tt/$den:tt) => {{
-        let q = std::format!("{:?}/{:?}", $num, $den);
-        Edn::Rational(q)
+        Edn::Rational(($num, $den))
     }};
 
     (:$key:tt) => {{

--- a/tests/deserialize.rs
+++ b/tests/deserialize.rs
@@ -130,10 +130,7 @@ mod test {
             Edn::from_str("-43.5143").unwrap(),
             Edn::Double(edn::Double::from(-43.5143))
         );
-        assert_eq!(
-            Edn::from_str("43/5143").unwrap(),
-            Edn::Rational("43/5143".to_string())
-        );
+        assert_eq!(Edn::from_str("43/5143").unwrap(), Edn::Rational((43, 5143)));
         assert_eq!(
             Edn::from_str("999999999999999999999.0").unwrap(),
             Edn::Double(edn::Double::from(1e21f64))

--- a/tests/emit_json.rs
+++ b/tests/emit_json.rs
@@ -110,14 +110,14 @@ mod tests {
                 Edn::Bool(false),
                 Edn::Key(":f".to_string()),
                 Edn::Nil,
-                Edn::Rational("3/4".to_string()),
+                Edn::Rational((3, 4)),
                 Edn::Set(Set::new(set! {
-                    Edn::Rational("3/4".to_string())
+                    Edn::Rational((3, 4))
                 })),
             ])),
             Edn::Map(Map::new(map![
                     String::from("false") => Edn::Key(":f".to_string()),
-                    String::from("nil") => Edn::Rational("3/4".to_string()),
+                    String::from("nil") => Edn::Rational((3, 4)),
                     String::from(":my-crazy-map") => Edn::Map(Map::new(map![
                         String::from("false") => Edn::Map(
                             Map::new( map![
@@ -125,7 +125,7 @@ mod tests {
                             ])),
                         String::from("nil") => Edn::Vector(
                             Vector::new( vec![
-                                Edn::Rational("3/4".to_string()),
+                                Edn::Rational((3, 4)),
                                 Edn::Int(1i64)
                             ]))
                 ]))

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -15,7 +15,7 @@ mod tests {
             edn!("this is a string"),
             Edn::Str("this is a string".to_string())
         );
-        assert_eq!(edn!(3 / 4), Edn::Rational("3/4".to_string()));
+        assert_eq!(edn!(3 / 4), Edn::Rational((3, 4)));
         assert_eq!(edn!(true), Edn::Bool(true));
         assert_eq!(edn!(false), Edn::Bool(false));
         assert_eq!(edn!(nil), Edn::Nil);
@@ -39,7 +39,7 @@ mod tests {
             Edn::Bool(false),
             Edn::Key(":f".to_string()),
             Edn::Nil,
-            Edn::Rational("3/4".to_string()),
+            Edn::Rational((3, 4)),
         ]));
 
         assert_eq!(edn!([ sym 1.2 3 false :f nil 3/4]), expected);
@@ -54,7 +54,7 @@ mod tests {
             Edn::Bool(false),
             Edn::Key(":f".to_string()),
             Edn::Nil,
-            Edn::Rational("3/4".to_string()),
+            Edn::Rational((3, 4)),
         ]));
 
         assert_eq!(edn!((1 1.2 3 false :f nil 3/4)), expected);
@@ -64,7 +64,7 @@ mod tests {
     fn parse_simple_map() {
         let expected = Edn::Map(Map::new(map! {
             String::from("1.2") => Edn::Bool(false),
-            String::from(":b") => Edn::Rational(String::from("3/4"))
+            String::from(":b") => Edn::Rational((3, 4))
         }));
 
         assert_eq!(edn!({1.2 false, :b 3/4}), expected);
@@ -80,7 +80,7 @@ mod tests {
                 Edn::Bool(false),
                 Edn::Key(":f".to_string()),
                 Edn::Nil,
-                Edn::Rational("3/4".to_string()),
+                Edn::Rational((3, 4)),
             ])),
         ]));
 
@@ -97,7 +97,7 @@ mod tests {
                 Edn::Bool(false),
                 Edn::Key(":f".to_string()),
                 Edn::Nil,
-                Edn::Rational("3/4".to_string()),
+                Edn::Rational((3, 4)),
             ])),
         ]));
 
@@ -112,7 +112,7 @@ mod tests {
             Edn::Int(3),
             Edn::Map(Map::new(map![
                     String::from("false") => Edn::Key(":f".to_string()),
-                    String::from("nil") => Edn::Rational("3/4".to_string())
+                    String::from("nil") => Edn::Rational((3, 4))
             ])),
         ]));
 
@@ -132,7 +132,7 @@ mod tests {
                         ])),
                     String::from("nil") => Edn::Vector(
                         Vector::new( vec![
-                            Edn::Rational("3/4".to_string()),
+                            Edn::Rational((3, 4)),
                             Edn::Int(1i64)
                         ]))
             ])),

--- a/tests/parse_sets.rs
+++ b/tests/parse_sets.rs
@@ -24,7 +24,7 @@ mod tests {
             Edn::Bool(false),
             Edn::Key(":f".to_string()),
             Edn::Nil,
-            Edn::Rational("3/4".to_string())
+            Edn::Rational((3, 4))
         }));
 
         assert_eq!(edn!(#{1 1.2 3 false :f nil 3/4}), expected);
@@ -41,13 +41,13 @@ mod tests {
                     Edn::Bool(false),
                     Edn::Key(":f".to_string()),
                     Edn::Nil,
-                    Edn::Rational("3/4".to_string())
+                    Edn::Rational((3, 4))
             ])),
             Edn::Vector(
                 Vector::new( vec![
                     Edn::Bool(true),
                     Edn::Key(":b".to_string()),
-                    Edn::Rational("12/5".to_string())
+                    Edn::Rational((12, 5))
             ]))
         }));
 


### PR DESCRIPTION
Partial discussion at edn-rs#134

It makes no sense to be able to construct or for the library to handle cases where users create `Edn::Rational("lolfoobar")`.