### PR TITLE
Fuzzing fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ fn complex_ok() -> Result<(), EdnError> {
     - [x] String `"\"string\""`
     - [x] Numbers `"324352"`, `"3442.234"`, `"3/4"`
     - [x] Keywords `:a`
-    - [x] Symbol `sym-bol-s` with a maximum of 200 chars
+    - [x] Symbol `sym-bol-s`
     - [x] Vector `"[1 :2 \"d\"]"`
     - [x] List `"(1 :2 \"d\")"`
     - [x] Set `"#{1 2 3}"`

--- a/src/deserialize/parse.rs
+++ b/src/deserialize/parse.rs
@@ -205,11 +205,6 @@ fn num_den_from_slice(slice: impl AsRef<str>) -> Option<(i64, u64)> {
 }
 
 fn read_number(n: char, chars: &mut iter::Enumerate<core::str::Chars<'_>>) -> Result<Edn, Error> {
-    let i = chars
-        .clone()
-        .next()
-        .ok_or_else(|| Error::ParseEdn("Could not identify symbol index".to_string()))?
-        .0;
     let c_len = chars
         .clone()
         .take_while(|(_, c)| !c.is_whitespace() && !DELIMITERS.contains(c))
@@ -286,7 +281,7 @@ fn read_number(n: char, chars: &mut iter::Enumerate<core::str::Chars<'_>>) -> Re
             read_symbol(n.next().unwrap_or(' '), &mut n.enumerate())
         }
         _ => Err(Error::ParseEdn(format!(
-            "{number} could not be parsed at char count {i} with radix {radix}"
+            "{number} could not be parsed with radix {radix}"
         ))),
     }
 }

--- a/src/deserialize/parse.rs
+++ b/src/deserialize/parse.rs
@@ -139,7 +139,7 @@ fn read_symbol(a: char, chars: &mut iter::Enumerate<core::str::Chars<'_>>) -> Re
     let c_len = chars
         .clone()
         .enumerate()
-        .take_while(|&(i, c)| i <= 200 && !c.1.is_whitespace() && !DELIMITERS.contains(&c.1))
+        .take_while(|&(_, c)| !c.1.is_whitespace() && !DELIMITERS.contains(&c.1))
         .count();
     let i = chars
         .clone()
@@ -290,7 +290,7 @@ fn read_char(chars: &mut iter::Enumerate<core::str::Chars<'_>>) -> Result<Edn, E
     let element = chars
         .clone()
         .enumerate()
-        .take_while(|&(i, c)| i <= 200 && !c.1.is_whitespace())
+        .take_while(|&(_, c)| !c.1.is_whitespace())
         .map(|(_, c)| c.1)
         .collect::<String>();
 

--- a/src/edn/mod.rs
+++ b/src/edn/mod.rs
@@ -230,6 +230,16 @@ impl core::fmt::Display for Map {
     }
 }
 
+fn char_to_edn(c: char) -> String {
+    match c {
+        '\n' => "\\newline".to_string(),
+        '\r' => "\\return".to_string(),
+        ' ' => "\\space".to_string(),
+        '\t' => "\\tab".to_string(),
+        _ => format!("\\{c}"),
+    }
+}
+
 impl core::fmt::Display for Edn {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let text = match self {
@@ -246,7 +256,7 @@ impl core::fmt::Display for Edn {
             Self::Double(d) => format!("{d}"),
             Self::Rational((n, d)) => format!("{n}/{d}"),
             Self::Bool(b) => format!("{b}"),
-            Self::Char(c) => format!("\\{c}"),
+            Self::Char(c) => char_to_edn(*c),
             Self::Nil => String::from("nil"),
             Self::Empty => String::new(),
             Self::Tagged(tag, edn) => format!("#{tag} {edn}"),

--- a/tests/deserialize.rs
+++ b/tests/deserialize.rs
@@ -945,4 +945,46 @@ mod test {
             ))
         );
     }
+
+    #[test]
+    fn special_chars() {
+        let edn = "[\\space \\@ \\` \\tab \\return \\newline \\# \\% \\' \\g \\( \\* \\j \\+ \\, \\l \\- \\. \\/ \\0 \\2 \\r \\: \\; \\< \\\\ \\] \\} \\~ \\? \\_]";
+
+        assert_eq!(
+            Edn::from_str(edn).unwrap(),
+            Edn::Vector(Vector::new(vec![
+                Edn::Char(' '),
+                Edn::Char('@'),
+                Edn::Char('`'),
+                Edn::Char('\t'),
+                Edn::Char('\r'),
+                Edn::Char('\n'),
+                Edn::Char('#'),
+                Edn::Char('%'),
+                Edn::Char('\''),
+                Edn::Char('g'),
+                Edn::Char('('),
+                Edn::Char('*'),
+                Edn::Char('j'),
+                Edn::Char('+'),
+                Edn::Char(','),
+                Edn::Char('l'),
+                Edn::Char('-'),
+                Edn::Char('.'),
+                Edn::Char('/'),
+                Edn::Char('0'),
+                Edn::Char('2'),
+                Edn::Char('r'),
+                Edn::Char(':'),
+                Edn::Char(';'),
+                Edn::Char('<'),
+                Edn::Char('\\'),
+                Edn::Char(']'),
+                Edn::Char('}'),
+                Edn::Char('~'),
+                Edn::Char('?'),
+                Edn::Char('_'),
+            ]))
+        );
+    }
 }

--- a/tests/deserialize.rs
+++ b/tests/deserialize.rs
@@ -684,6 +684,9 @@ mod test {
             Edn::Symbol("your-hair!-is+_parsed?".to_string()),
         ]));
         assert_eq!(edn, expected);
+
+        let lorem = "Lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit-sed-do-eiusmod-tempor-incididunt-ut-labore-et-dolore-magna-aliqua.-Ut-enim-ad-minim-veniam-quis-nostrud-exercitation-ullamco-laboris-nisi-ut-aliquip-ex-ea-commodo-consequat.-Duis-aute-irure-dolor-in-reprehenderit-in-voluptate-velit-esse-cillum-dolore-eu-fugiat-nulla-pariatur.-Excepteur-sint-occaecat-cupidatat-non-proident-sunt-in-culpa-qui-officia-deserunt-mollit-anim-id-est-laborum".to_string();
+        assert_eq!(Edn::from_str(lorem.as_str()).unwrap(), Edn::Symbol(lorem));
     }
 
     #[test]

--- a/tests/deserialize.rs
+++ b/tests/deserialize.rs
@@ -124,6 +124,7 @@ mod test {
 
     #[test]
     fn parse_number() {
+        assert_eq!(Edn::from_str("7").unwrap(), Edn::UInt(7));
         assert_eq!(Edn::from_str("143").unwrap(), Edn::UInt(143));
         assert_eq!(Edn::from_str("-435143").unwrap(), Edn::Int(-435_143));
         assert_eq!(
@@ -852,14 +853,14 @@ mod test {
         assert_eq!(
             Edn::from_str("42invalid123"),
             Err(Error::ParseEdn(
-                "42invalid123 could not be parsed at char count 1 with radix 10".to_string()
+                "42invalid123 could not be parsed with radix 10".to_string()
             ))
         );
 
         assert_eq!(
             Edn::from_str("0xxyz123"),
             Err(Error::ParseEdn(
-                "xyz123 could not be parsed at char count 1 with radix 16".to_string()
+                "xyz123 could not be parsed with radix 16".to_string()
             ))
         );
 

--- a/tests/emit.rs
+++ b/tests/emit.rs
@@ -25,5 +25,8 @@ mod tests {
     fn char_formatting() {
         let edn = edn_to_string_unwrap("(\\b \\g \\m)");
         assert_eq!(edn, "(\\b \\g \\m)");
+
+        assert_eq!(edn_to_string_unwrap("[\\space \\@ \\` \\tab \\return \\newline \\# \\% \\' \\g \\( \\* \\j \\+ \\, \\l \\- \\. \\/ \\0 \\2 \\r \\: \\; \\< \\\\ \\] \\} \\~ \\? \\_]"),
+        "[\\space \\@ \\` \\tab \\return \\newline \\# \\% \\' \\g \\( \\* \\j \\+ \\, \\l \\- \\. \\/ \\0 \\2 \\r \\: \\; \\< \\\\ \\] \\} \\~ \\? \\_]")
     }
 }


### PR DESCRIPTION
Cleaned up/rebased version of https://github.com/edn-rs/edn-rs/pull/125.

This PR is mostly for the tests and history, the actual parsing implementation (clone version) will be replaced in a future PR with the EdnError/parse rework as seen in https://github.com/Grinkers/edn-rs/pull/6. I can squash it all, but I think this will make things easier to review.