### PR TITLE
Dev dep `edn-derive` points back to Org's version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { version = "1.33", features = ["full"] }
 criterion = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-edn-derive = { git = "https://github.com/Grinkers/edn-derive.git" } # TODO pin to proper release 
+edn-derive = { git = "https://github.com/edn-rs/edn-derive.git" } # TODO pin to release
 
 [dev-dependencies.cargo-husky]
 version = "1"


### PR DESCRIPTION
https://github.com/edn-rs/edn-derive/pull/37 has been merged.