### PR TITLE
Clean up readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,13 @@
 # edn-rs
 [![Build Status](https://travis-ci.org/edn-rs/edn-rs.svg?branch=master)](https://travis-ci.org/edn-rs/edn-rs) [![codecov](https://codecov.io/gh/edn-rs/edn-rs/branch/master/graph/badge.svg?token=4VMVTZTN8A)](https://codecov.io/gh/edn-rs/edn-rs)
 
-Crate to parse and emit EDN
-* **This lib does not make effort to conform the EDN received to EDN Spec.** The lib that generated this EDN should be responsible for this. For more information on Edn Spec please visit: https://github.com/edn-format/edn.
+A crate to parse and emit EDN [`(Extensible Data Notation)`](https://github.com/edn-format/edn)
 * MSRV (minimal supported rust version) is stable minus 2 versions. Once stable (1.0.0), the plan is to indefinitely maintain the MSRV.
 * Current library maintainer is Kevin Nakamura (@Grinkers)
 
-Our **MTTA** (Mean time to acknowledge) is around `one day`;
-<!---->
-and our **TTR** (Time To Resolve) can vary from a `few days to a couple of weeks` depending on the number of issues.
-
-Current example usage in:
-* [crate `transistor`](https://github.com/naomijub/transistor);
-* [`atm-crux`](https://github.com/naomijub/atm-crux);
-* [Rust/Clojure FFI. Deserialize Clojure Edn into Rust Struct](https://github.com/naomijub/JVM-rust-ffi/tree/master/clj-rs);
+Full integration examples:
+* [`edn-rs fuzzer` with full JVM interop](https://github.com/edn-rs/edn-rs_fuzzer);
+* [`pico-edn` no_std running on a Cortex-M0+ (rp2040)](https://github.com/edn-rs/pico-edn);
 
 ## Usage
 
@@ -27,7 +21,7 @@ edn-rs = "0.17.4"
 
 ### no_std
 To use `edn-rs` without any additional dependencies, disable default features.
-`edn-rs` still relies on `alloc`. In no_std environments, you must supply your own `#[global_allocator]`
+`edn-rs` still relies on `alloc`. In no_std environments, you must supply your own `#[global_allocator]`.
 
 ```toml
 [dependencies]
@@ -38,16 +32,6 @@ edn-rs = { version = "0.17.4", default-features = false }
 * `std`: Implements (de)serialization for Hashmap and HashSet; Also some floating point functionality.
 * `sets`: Implements (de)serialization for EDN sets. Depends on `ordered-float`.
 * `json`: Implements json->edn and edn->json conversions. Depends on `regex`.
-
-## Simple time-only benchmarks of `edn-rs` against Clojure Edn
-* Link to benchmarks implementation [here](https://github.com/naomijub/edn-duration-benchmark/blob/master/README.md)
-
-| Method\Lang 	| Rust --release 	| Rust --debug 	| Clojure 	|
-|-	|-	|-	|-	|
-| parse string 	| 77.57µs 	| 266.479µs 	| 4.712235 milis 	|
-| get-in/navigate (3 blocks)	| 4.224µs	| 22.861µs 	| 26.333 µs 	|
-| Deserialize to struct 	| 110.358µs 	| 357.054µs 	| 4.712235 milis 	|
-| parse with criterium | 11.348µs | - | 23.230µs|
 
 ## Quick reference
 
@@ -367,7 +351,7 @@ fn complex_ok() -> Result<(), EdnError> {
 
     let edn = Edn::from_str(edn_str)?;
     println!("{:?}", edn.to_string());
-//    "{:list: [{:age 66, :cool true, :name \"rose\", }, {:age 33, :cool false, :name \"josh\", }, {:age 296, :cool true, :name \"eva\", }, ], }"
+    // "{:list: [{:age 66, :cool true, :name \"rose\", }, {:age 33, :cool false, :name \"josh\", }, {:age 296, :cool true, :name \"eva\", }, ], }"
 
     Ok(())
 }

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # edn-rs
 [![Build Status](https://travis-ci.org/edn-rs/edn-rs.svg?branch=master)](https://travis-ci.org/edn-rs/edn-rs) [![codecov](https://codecov.io/gh/edn-rs/edn-rs/branch/master/graph/badge.svg?token=4VMVTZTN8A)](https://codecov.io/gh/edn-rs/edn-rs)
 
-Crate to parse and emit EDN 
+Crate to parse and emit EDN
 * **This lib does not make effort to conform the EDN received to EDN Spec.** The lib that generated this EDN should be responsible for this. For more information on Edn Spec please visit: https://github.com/edn-format/edn.
 * MSRV (minimal supported rust version) is stable minus 2 versions. Once stable (1.0.0), the plan is to indefinitely maintain the MSRV.
 * Current library maintainer is Kevin Nakamura (@Grinkers)
 
-Our **MTTA** (Mean time to acknowledge) is around `one day`; 
+Our **MTTA** (Mean time to acknowledge) is around `one day`;
 <!---->
 and our **TTR** (Time To Resolve) can vary from a `few days to a couple of weeks` depending on the number of issues.
 
@@ -284,7 +284,7 @@ fn main() {
     assert_eq!(edn, json_to_edn(json));
 
     let complex_json = String::from(r#"{
-            "people": 
+            "people":
             [
                 {
                     "name": "eva",
@@ -307,27 +307,27 @@ fn main() {
 
  **Emits a JSON** from type `edn_rs::Edn`.
  * The associated emthod is `to_json(&self)` and it requires feature `json` to be activated. To enable this feature add to your `Cargo.toml`  dependencies the following line `edn-rs = { version = 0.17.4", features = ["json"] }`.
- 
+
 ```rust
 use std::str::FromStr;
 fn complex_json() {
-    let edn = "{ 
-        :people-list [ 
-            { :first-name \"eva\", :age 22 }, 
-            { :first-name \"Julia\", :age 32.0 } 
-        ], 
-        :country-or-origin \"Brazil\", 
-        :queerentener true, 
+    let edn = "{
+        :people-list [
+            { :first-name \"eva\", :age 22 },
+            { :first-name \"Julia\", :age 32.0 }
+        ],
+        :country-or-origin \"Brazil\",
+        :queerentener true,
         :brain nil }";
     let parsed_edn : edn_rs::Edn = edn_rs::Edn::from_str(edn).unwrap();
     let actual_json = parsed_edn.to_json();
     let expected = String::from(
-        "{\"brain\": null, 
-          \"countryOrOrigin\": \"Brazil\", 
+        "{\"brain\": null,
+          \"countryOrOrigin\": \"Brazil\",
           \"peopleList\": [
-              {\"age\": 22, \"firstName\": \"eva\"}, 
+              {\"age\": 22, \"firstName\": \"eva\"},
               {\"age\": 32.0, \"firstName\": \"Julia\"}
-            ], 
+            ],
           \"queerentener\": true}",
     );
     assert_eq!(
@@ -400,7 +400,7 @@ fn complex_ok() -> Result<(), EdnError> {
     - [x] Maps in general `"{:a 2 :b {:3 \"4\"}}"`, `"{:a 2 :b [:3 \"4\"]}"`
 - [x] Multiple simple data structures in one another (Map and Set in a vector)
 - [x] Multi deepen data structures (Map in a Set in a List in a  Vec in a Vec)
-- [x] Navigate through Edn Data 
+- [x] Navigate through Edn Data
     - [x] Navigate through Sets. DOne by `set_iter`
 - [x] Json to Edn
     - [x] Json String to EDN String


### PR DESCRIPTION
# Rational

## Spec
I don't think it's worth mentioning we aren't the clojure library `spec` as the very first thing. Anybody who reads it might be confused. "This isn't a thing". Especially when that thing is a clojure library, nothing to do with EDN.

## Examples
Not great having examples be archived examples. The JVM example, while trying to be minimal, leaks memory https://github.com/naomijub/JVM-rust-ffi/blob/master/clj-rs/clj-rust/src/lib.rs#L50. The fuzzer has round-trip using JNI. I also transferred `pico-edn` to this Org.

## Benchmarks
Completely outdated. 