### PR TITLE
`to` collections return reference instead of move data out of `Edn`.

### DIFF
--- a/src/edn/mod.rs
+++ b/src/edn/mod.rs
@@ -102,8 +102,8 @@ impl Vector {
     }
 
     #[must_use]
-    pub fn to_vec(self) -> Vec<Edn> {
-        self.0
+    pub const fn to_vec(&self) -> &Vec<Edn> {
+        &self.0
     }
 }
 
@@ -122,8 +122,8 @@ impl List {
     }
 
     #[must_use]
-    pub fn to_vec(self) -> Vec<Edn> {
-        self.0
+    pub const fn to_vec(&self) -> &Vec<Edn> {
+        &self.0
     }
 }
 
@@ -144,8 +144,8 @@ impl Set {
     }
 
     #[must_use]
-    pub fn to_set(self) -> BTreeSet<Edn> {
-        self.0
+    pub const fn to_set(&self) -> &BTreeSet<Edn> {
+        &self.0
     }
 }
 
@@ -164,8 +164,8 @@ impl Map {
     }
 
     #[must_use]
-    pub fn to_map(self) -> BTreeMap<String, Edn> {
-        self.0
+    pub const fn to_map(&self) -> &BTreeMap<String, Edn> {
+        &self.0
     }
 }
 

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -10,11 +10,11 @@ use crate::edn::{rational_to_double, Edn};
 #[allow(clippy::module_name_repetitions)]
 pub fn display_as_json(edn: &Edn) -> String {
     match edn {
-        Edn::Vector(v) => vec_to_json(&v.clone().to_vec()),
+        Edn::Vector(v) => vec_to_json(v.to_vec()),
         #[cfg(feature = "sets")]
-        Edn::Set(s) => set_to_json_vec(&s.clone().to_set()),
-        Edn::Map(map) => map_to_json(&map.clone().to_map()),
-        Edn::List(l) => vec_to_json(&l.clone().to_vec()),
+        Edn::Set(s) => set_to_json_vec(s.to_set()),
+        Edn::Map(map) => map_to_json(map.to_map()),
+        Edn::List(l) => vec_to_json(l.to_vec()),
         Edn::Key(key) => format!("{:?}", kebab_to_camel(key)),
         Edn::Symbol(s) | Edn::Str(s) => format!("{s:?}"),
         Edn::Int(n) => format!("{n}"),


### PR DESCRIPTION
This is a breaking change, but right now iterating over nested collections is a huge pain. It requires cloning the entire Edn object each time.

I'm not particularly happy with the naming, but it's the least breaking version for now. Another example of needing to think really hard on https://github.com/edn-rs/edn-rs/issues/136. What we really want is a something like [seq](https://clojuredocs.org/clojure.core/seq) but I'm not sure how viable that is in rust.